### PR TITLE
pass environment variable to scons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -20,8 +20,7 @@ conf.UpdateOptions(options)
 # tools = ['opengl']
 # env = config.ALEASolution(options, tools)
 # oldies
-env = Environment(options=options)
-
+env = Environment(ENV = os.environ, options=options)
 conf.Update(env)
 
 # Generate Help available with the cmd scons -h


### PR DESCRIPTION
In a windows conda environment, with gcc installed in the environment, scons did not find the path to gcc when launching scons.
To solve it, I had to pass ENV argument in sconscript. Good or bad idea ?