### PR TITLE
Avoid using  `os.path.exists` with Windows OS

### DIFF
--- a/src/alinea/caribu/caribu_shell.py
+++ b/src/alinea/caribu/caribu_shell.py
@@ -77,8 +77,18 @@ def _abrev(fnc, maxlg=1):
     abreviate a text string containing a path or a file content to the first maxlg lines,
     addind '...' when the number of libnes is greater than maxlg
     """
-    if fnc is None or os.path.exists(fnc):
-        return str(fnc)
+    # Check if fnc is a path or a file content
+    if os.name == 'nt':
+        # we avoid using os.path.exists on Windows because of
+        # its limit of number of characters
+        if fnc is None or fnc.find("/") != -1 or fnc.find("\\") != -1:
+            return str(fnc)
+    
+    # os.path.exists works on unix systems
+    else :
+        if fnc is None or os.path.exists(fnc):
+            return str(fnc)
+    
     lines = fnc.splitlines()
     if maxlg <= 1:
         return lines[0] + ' ... '
@@ -336,7 +346,7 @@ class Caribu(object):
                 self.pattern = Path(fn.basename())
 
         if self.sensor is not None:
-            if os.path.exists(self.sensor):
+            if str(self.sensor).endswith('.can'):
                 fn = Path(self.sensor)
                 fn.copy(d / fn.basename())
             else:


### PR DESCRIPTION
I've encountered a `path too long` error with Windows and virtual sensors in CARIBU.

Using `os.path.exists` on large string object can exceed the maximum number of characters for a path within Windows OS. With virtual sensors, this limit can be reached. This is a proposal to avoid this limitation.