### PR TITLE
Agregate soil results with the rest of the scene

### DIFF
--- a/src/alinea/caribu/CaribuScene.py
+++ b/src/alinea/caribu/CaribuScene.py
@@ -35,9 +35,18 @@ import tempfile
 
 def _agregate(values, indices, fun=sum):
     """ performs aggregation of outputs along indices """
+    
+    # test if indices contains multiple types element
+    if len(set([type(x) for x in indices])) > 1 :
+        # if so we only consider the "soil" index
+        indices = list(map(lambda x: -9999 if x == "soil" else x , indices))
+
     ag = {}
     for key, group in groupby(sorted(zip(indices, values), key=lambda x: x[0]),
                               lambda x: x[0]):
+        # we return to a string key for "soil"
+        if key == -9999 : key = "soil"
+
         vals = [elt[1] for elt in group]
         try:
             ag[key] = fun(vals)

--- a/test/test_caribu_soilmesh.py
+++ b/test/test_caribu_soilmesh.py
@@ -1,0 +1,26 @@
+from alinea.caribu.CaribuScene import CaribuScene
+from alinea.caribu.data_samples import data_path
+
+import openalea.plantgl.all as pgl
+
+if __name__ == "__main__":
+    print("--- test soilmesh")
+
+    # Scene in Caribu format
+    points = [(0.1, 0.1, 0.1), (0.1, 2, 0.1), (2, 2, 1), (2, 0.1, 1)]  
+    triangles = {888 : [[points[0], points[1], points[2]], [points[0], points[2], points[3]]]}
+
+    # environment parameters
+    debug = False
+    sky = data_path('zenith.light')
+    opts = {'par' : {888 : (0.10, 0.05)}}
+    domain = ((0, 0), (2,2))
+
+    # radiosity
+    c_scene = CaribuScene(scene=triangles, light=sky, opt=opts, soil_mesh = 1, debug = debug, pattern=domain)
+    raw, aggregated = c_scene.run(direct=True, infinite=False)
+    q, e = c_scene.getSoilEnergy()
+
+    print("Incident energy: %f , horizontal irradiance: %f" % (e, q))
+    
+    print("--- done")


### PR DESCRIPTION
An issue is encounter with `sorted` function in `_agregate` function, l.35 of CaribuScene.py while activating soil_mesh.

The activation of soil_mesh leads to extend the `groups` list (l.540 CaribuScene.run(...) in CaribuScene.py) with string labels `"soil"` . This list is given afterward in  l.655 `raw[band][k] = _agregate(output[k], groups, list)` . This leads to a `TypeError` given by the `sorted` function, because the list `groups`  blends `int` and `str` elements.

I didn't want to replace the soil label in all the package, so only in the function `_agregate` we replace `"soil"` by -9999 (I supposed all the other labels were >= 0), and then put it back to `"soil"`. 

This bug was encountered with the package alinea.caribu on [fredboudon](https://anaconda.org/fredboudon/alinea.caribu)