### PR TITLE
Remove warnings

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -29,19 +29,18 @@ requirements:
   run:
     - python x.x
     - path              # path.py is outdated
-    #- openalea.plantgl
-    #- openalea.mtg
+    - openalea.plantgl
+    - openalea.mtg
 
-# Remove test due to a bug: tests are run before build is finished...
-#test:
-  #requires:
-  #  - pytest
-  #imports:
-  #  - alinea.caribu
-  #source_files:
-  #  - test/*.py
-  #commands:
-  # - pytest -v
+test:
+  requires:
+    - pytest
+  imports:
+    - alinea.caribu
+  source_files:
+    - test/*.py
+  commands:
+   - pytest -v
 
 about:
   home: {{ data.get('url') }}

--- a/src/cpp/Canestra/src/bsp.cpp
+++ b/src/cpp/Canestra/src/bsp.cpp
@@ -13,7 +13,7 @@ void BSP::destruction_boite(){
 //modif pour traiter un volume fixe par l'user  (cas infini) - MC 95
 void BSP::volume_englobant_scene(reel *bornemin, reel *bornemax,ListeD<Diffuseur*>& Ldiff_scene){
   //modif : pour l'infini : inclure les a-cheval
-  register int i,nbs;
+  int i,nbs;
   Diffuseur *pdiff;
   Point pt;
   // char bps[3];//Bon Pour le Service 
@@ -79,7 +79,7 @@ inline void BSP::ajouter(Diffuseur* no_diff){
 }
 
 void BSP::copie_boite(BSP* B1){
-  register int i;
+  int i;
   
   for (i=0; i<3; i++){
     B1->position_max[i]=position_max[i];
@@ -131,7 +131,7 @@ void BSP::decoupe_boite(int axe, BSP* B1, BSP* B2, double frontier){
 }
 
 bool BSP::contient(Point &P) {
-  register int ii;
+  int ii;
   bool dedans=true;
   for(ii=0;ii<3;ii++) {
     dedans &= (P[ii]<position_max[ii]) && (P[ii]>position_min[ii]);

--- a/src/cpp/Canestra/src/canopy_E.cpp
+++ b/src/cpp/Canestra/src/canopy_E.cpp
@@ -143,7 +143,7 @@ void zFF(void *, int, int, void*) {
 }//zFF()
 
 static  int addbox(BSP * box,reel dx,reel dy, Boxi *Tabox,int ind) {
-  register int i;
+  int i;
   if(ind!=0) {
     if(box->nb_diffuseur()==0)
        return ind;
@@ -169,8 +169,8 @@ void Canopy::calc_FF_Bfar(SPMAT *FF,
 			  bool bias,
 			  double denv,
 			  int nbsim) {
-  register int p,t,b,nb_rec=0,nb_emi=0,nb_test=0,cum_box=0,nb_error=0,nb_ff,nop=0;;
-  register unsigned char i,nb_box,pr=0;
+  int p,t,b,nb_rec=0,nb_emi=0,nb_test=0,cum_box=0,nb_error=0,nb_ff,nop=0;;
+  unsigned char i,nb_box,pr=0;
   int pmax,tmax,inc[3],Gi[3];
   int n,i_sup,i_inf=0,idx,idxn;
   Diffuseur *diffR, *diffE;
@@ -452,7 +452,7 @@ void Canopy::calc_FF_Bfar(SPMAT *FF,
 
 void Canopy::calc_FF(SPMAT *FF){;
   Point G,T;
-  register unsigned char i,j;
+  unsigned char i,j;
   int n,i_sup,i_inf,idx;
   Diffuseur *diffR, *diffE;
   SPROW	*r_sup,*r_inf;
@@ -503,7 +503,7 @@ void Canopy::calc_FF(SPMAT *FF){
 #endif
 
 void Canopy::projplan(Vecteur &visee,bool infty, double* Bo) {
-  register int i,j,k,l,img_surf;
+  int i,j,k,l,img_surf;
   Point roof[4];
   REELLE **Zbuf,**pZbuf,*ptZ;
   double tx,ty,costeta,Apix;
@@ -668,7 +668,7 @@ void Canopy::projplan(Vecteur &visee,bool infty, double* Bo) {
   bool up,down,pastoutvu;
   //taille ecran stocke en tmp et dz
   //variable pr periodic infini
-  register signed char acv_idx,acv_fin=0;
+  signed char acv_idx,acv_fin=0;
   Vecteur delta[3];
   
   delta[0][0]=delta[2][0]=0.0;
@@ -968,8 +968,8 @@ void Canopy::projplan(Vecteur &visee,bool infty, double* Bo) {
 
 void colorie_triangle( void * tria,void *Zprim, REELLE **Zbuf,const Punkt a,const Punkt b,const Punkt c, int Tx, int Ty,double tx, double ty,void (*f)(void *, int, int, void*)){
   double penteL,penteR,xL,xR,zL,yrel,vab,vac,vbc,z,dz; // L Left, R  Right
-  register int i,j, iR,iL, deby,finy;
-  register signed char sens;
+  int i,j, iR,iL, deby,finy;
+  signed char sens;
   double K[2];
   
   //            a           b ______ c 
@@ -1057,8 +1057,8 @@ void colorie_triangle( void * tria,void *Zprim, REELLE **Zbuf,const Punkt a,cons
 /***** colorie_capteur() *****/
  void colorie_capteur(REELLE **Zbuf,Punkt a,Punkt b,Punkt c, int Tx, int Ty,double tx, double ty,int& pB0){
  double penteL,penteR,xL,xR,zL,yrel,vab,vac,vbc,z,dz; // L Left, R  Right
-  register int i,j, iR,iL, deby,finy;
-  register signed char sens;
+  int i,j, iR,iL, deby,finy;
+  signed char sens;
   double K[2];
   
   //            a           b ______ c 
@@ -1130,7 +1130,7 @@ void colorie_triangle( void * tria,void *Zprim, REELLE **Zbuf,const Punkt a,cons
 
 void Canopy::data3d(int tx,int ty,Vecteur &visee,
 		    bool infty,long int **&Zno){
-  register int i,j,k,l,img_surf;
+  int i,j,k,l,img_surf;
   Image imgZ (tx,ty,(char*)"proz.ppm");
   long int **pZno;
   REELLE **Zbuf,**pZbuf,*ptZ;
@@ -1333,7 +1333,7 @@ void Canopy::data3d(int tx,int ty,Vecteur &visee,
   Vecteur SvE; // SvE : Scene vers Ecran
   Vecteur delta[3];
   bool up,down,pastoutvu;
-  register signed char acv_idx,acv_fin=0;
+  signed char acv_idx,acv_fin=0;
   //taille ecran stocke en tmp et dz
 
   imgZ.raz(-10);
@@ -1507,7 +1507,7 @@ void color_triangle( void * tria,void *Zprim, double **Zbuf,const Punkt a,const 
   double penteL,penteR,xL,xR,zL,yrel,vab,vac,vbc,z,dz; // L Left, R  Right
   int i,j, iR,iL, deby,finy;
   int Ae[2],Be[2],Ce[2];
-  register signed char sens;
+  signed char sens;
   double K[2];
   
   //            a           b ______ c 
@@ -1583,7 +1583,7 @@ void Canopy::calc_FF_Bfar(SPMAT *FF,VEC **Cfar,char * envname, double denv,int n
   Liste<Pointt> lpt; Punkt Pt1,Pt2; ; Primitive *pprim;
   Param_Inter parag;
   Diffuseur *pdiff;
-  register int i,j,k,l;
+  int i,j,k,l;
   double distZ,pente;
   Vecteur &w=prim->normal();
   //cout<<" w=vers? ";w.show();
@@ -1714,8 +1714,8 @@ void Canopy::calc_FF_Bfar(SPMAT *FF,VEC **Cfar,char * envname, double denv,int n
 
 #ifdef _Obsolete
 void Canopy::calc_FF_Bfar(SPMAT *FF,VEC **Cfar,char * envname, double denv,int nbsim) {
-  register int p,t,b,nb_rec=0,nb_emi=0,nb_test=0,cum_box=0;
-  register unsigned char i,nb_box,pr=0;
+  int p,t,b,nb_rec=0,nb_emi=0,nb_test=0,cum_box=0;
+  unsigned char i,nb_box,pr=0;
   int pmax,tmax,inc[3],Gi[3];
   SPROW	*r_sup,*r_inf;
   int n,i_sup,i_inf;

--- a/src/cpp/Canestra/src/canopy_io.cpp
+++ b/src/cpp/Canestra/src/canopy_io.cpp
@@ -9,7 +9,7 @@
 using namespace std ;
 
 #ifdef WIN32
-#include <windows.h>	// le + près possible de namespace
+#include <windows.h>	// le + prï¿½s possible de namespace
 #ifndef MINGW
 #undef min
 #undef max
@@ -24,8 +24,8 @@ using namespace std ;
 
 /*
 char clef_seg_in[12] ;	//  version char* de la clef numerique
-HANDLE	hSharedSegIn ;	// Handle du fichier mappé
-LPVOID	lpSharedSegIn ;	// pointeur LPVOID sur seg. partagé
+HANDLE	hSharedSegIn ;	// Handle du fichier mappï¿½
+LPVOID	lpSharedSegIn ;	// pointeur LPVOID sur seg. partagï¿½
 */
 /**************************************************************************
  *       Chargement de la scene : parse_can, read_shm                     *
@@ -107,7 +107,7 @@ inline char * endline(ifstream & fin){
     iKompteur++;
   }while(car!='\n');
   
-  // Apprends à utiliser les strings, Herve !!! // HA
+  // Apprends ï¿½ utiliser les strings, Herve !!! // HA
   istringstream isTmp (ligne.str()) ;  
   char *tmp1 = new char[LONG_LIGNE_CAN],
     *pline = new char[LONG_LIGNE_CAN] ;
@@ -577,12 +577,12 @@ long int Canopy::read_shm(
 	 <<" impossible =>exit" << "\n" ;
     exit(12);
   }
-  Ts=(Patch *)shmat(shmid,0,NULL);
+  Ts=(Patch *)shmat(shmid,0,int(NULL));
 #else
   // Win NT
      char clef_seg_in[12] ;	//  version char* de la clef numerique
-     HANDLE	hSharedSegIn ;	// Handle du fichier mappé
-     LPVOID	lpSharedSegIn ;	// pointeur LPVOID sur seg. partagé
+     HANDLE	hSharedSegIn ;	// Handle du fichier mappï¿½
+     LPVOID	lpSharedSegIn ;	// pointeur LPVOID sur seg. partagï¿½
 
       sprintf ( clef_seg_in, "%d", clef) ;
       assert ((hSharedSegIn = OpenFileMapping (
@@ -755,17 +755,17 @@ long int Canopy::read_shm(
   //liberation du shm
 #ifndef WIN32
   // Unix
-  shmdt((void*)shmid);
+  shmdt((void*)(size_t)shmid);
 #else
   // Win NT
     UnmapViewOfFile(lpSharedSegIn) ; // invalidation du ptr sur mem partagee
     // Ts = NULL ;		   // tester avant ...
-    CloseHandle(hSharedSegIn) ;	   // Fermeture du fichier mappé
+    CloseHandle(hSharedSegIn) ;	   // Fermeture du fichier mappï¿½
 #endif
 
    if(rejet){
      char Tmsg[100];
-     sprintf(Tmsg,">>>  Canopy[read_shm] ****** %d  rejected triangles ****",Nrejet);
+     snprintf(Tmsg,sizeof(Tmsg), ">>>  Canopy[read_shm] ****** %d  rejected triangles ****",Nrejet);
      cout <<Tmsg<<"\n";
      Ferr <<Tmsg<<"\n";
    }

--- a/src/cpp/Canestra/src/canopy_io.cpp
+++ b/src/cpp/Canestra/src/canopy_io.cpp
@@ -98,7 +98,7 @@ inline void not_yet(char * type){
 }// not_yet()
 
 inline char * endline(ifstream & fin){
-  register long int iKompteur=0;
+  long int iKompteur=0;
   char car;
   ostringstream ligne; // was ostrstream
   do {
@@ -960,7 +960,7 @@ inline Point isobary(Point&A, Point&B, Point&C){
 }//isobary()
 
 void Canopy::xabs(char* nx3d,double *bornemin,double *bornemax,bool normee)
-{ register int i,j,nb_prim=0,nb_seg=0,nb_face=0,color;
+{ int i,j,nb_prim=0,nb_seg=0,nb_face=0,color;
    double M,Emax=-1.0,Emin=9.9e12;
    int nbcol=203;
    Point G;
@@ -1061,7 +1061,7 @@ void Canopy::xabs(char* nx3d,double *bornemin,double *bornemax,bool normee)
 //-********************   Canopy:: xrad()    *******************
 
 void Canopy::xrad(char* nvar,double *bornemin,double *bornemax,bool normee)
- { register int i,j,nb_prim=0,nb_seg=0,nb_face=0,color;
+ { int i,j,nb_prim=0,nb_seg=0,nb_face=0,color;
    double M,Emax=-1.0,Emin=9.9e12;
    int nbcol=203;
    Point G;

--- a/src/cpp/Canestra/src/capteur.cpp
+++ b/src/cpp/Canestra/src/capteur.cpp
@@ -126,7 +126,7 @@ void Camera::capte(Rayon &strahl,Diffuseur *pinter,int nbray)
          weight*=taille*taille* fabs( strahl.par().direct().prod_scalaire(prim->normal()))/I.dist2(oldpar.origin());
 
          //maj de l'image
-         register int i,j;
+         int i,j;
          i= img->taille(0)-1-(int)fabs(dir.prod_scalaire(u)/taille*(img->taille(0)-1));
          j=(int)fabs(dir.prod_scalaire(v)/taille*(img->taille(1)-1));
          img->inc(i,j, weight ); 
@@ -173,7 +173,7 @@ void Camera::capte_visi(Rayon &strahl,Diffuseur *inter,int nbray)
          weight*=taille*taille* fabs(strahl.par().direct().prod_scalaire(prim->normal()))/I.dist2(oldpar.origin());   
 
          //maj de l'image
-         register int i,j;
+         int i,j;
          i= img->taille(0)-1-(int)fabs(dir.prod_scalaire(u)/taille*(img->taille(0)-1));
          j= (int)fabs(dir.prod_scalaire(v)/taille*(img->taille(1)-1));
          img->inc(i,j, weight ); 
@@ -191,7 +191,7 @@ void Camera::capte_visi(Rayon &strahl,Diffuseur *inter,int nbray)
 void Camera::colorie_triangle(Diffuseur * pdif,Point &a,Point &b,Point &c, Tabdyn<double, 2>& Zbuf, Tabdyn<Diffuseur *, 2>& Zprim,Image *pimg)
 // Vorsicht : Zbuf, Zprim, pdiff passes en variable globale (-lourd)
  { double penteL,penteR,xL,xR,zL,yrel,vab,vac,vbc,z,dz; // L Left, R  Right
-   register int i,j, iR,iL, deby,finy,sens;
+   int i,j, iR,iL, deby,finy,sens;
    Diffuseur *exdif;
    double K[2];
 
@@ -284,7 +284,7 @@ void Camera::calc_visi(Liste <Diffuseur*>& Ldiff)
    Liste<Point> lpt; Point Pt1,Pt2; ; Primitive *pprim;
    Param_Inter parag;
    Diffuseur *pdiff;
-   register int i,j,k,l;
+   int i,j,k,l;
    double distZ,pente;
    Vecteur &w=prim->normal();cout<<" w=vers? ";w.show();
    Vecteur SvE=E,EvI; // SvE : Scene vers Ecran, EvI : Ecran vers Image
@@ -414,8 +414,8 @@ void Camera::calc_visi(Liste <Diffuseur*>& Ldiff)
 void Camera::maj_stat()
  { double x;
 
-   for(register int i=0;i<img->taille(0);i++)
-     for(register int j=0;j<img->taille(1);j++)
+   for(int i=0;i<img->taille(0);i++)
+     for(int j=0;j<img->taille(1);j++)
          { x=img->val(i,j);
            moy->inc(i,j,x);
            x*=x;
@@ -432,8 +432,8 @@ void Camera::calc_stat(unsigned int niter=0)
  { raus(niter==0,"Capteur[calc_stat] Doit avoir le nb d'iteration en parametre!");
  // calcul de la moyenne et de la variance
    double x,test1=0, test2=0;
-   for(register int i=0;i<img->taille(0);i++)
-     for(register int j=0;j<img->taille(1);j++)
+   for(int i=0;i<img->taille(0);i++)
+     for(int j=0;j<img->taille(1);j++)
          { x=moy->val(i,j)/(double)niter;
            moy->maj(i,j,x);
            img->maj(i,j,x);

--- a/src/cpp/Canestra/src/diffuseur.cpp
+++ b/src/cpp/Canestra/src/diffuseur.cpp
@@ -20,7 +20,7 @@ ostream& operator << (ostream& out,Diffuseur & diff){
 #ifdef _NRJ
 //-*************** friend Emax() ****************************
 int maxE(Diffuseur *g,Diffuseur *d){
-  register double grad,drad;
+  double grad,drad;
 
   /*  grad=g->dRad();
   drad=d->dRad();

--- a/src/cpp/Canestra/src/envoi.cpp
+++ b/src/cpp/Canestra/src/envoi.cpp
@@ -8,7 +8,7 @@ main(int argc, char **argv){
   int n,t;
   double id;
   FILE * fout;
-  register int i,j,k;
+  int i,j,k;
   char cmd[50];
   int shmid;
   bool prog=false;

--- a/src/cpp/Canestra/src/ff.cpp
+++ b/src/cpp/Canestra/src/ff.cpp
@@ -138,7 +138,7 @@ static inline double env(int i,int j,double &denv,signed char tr) {
   if(Nc==0)
     return 0.0;
   else {
-    register int t,N_2;
+    int t,N_2;
     Vecteur dir;
     Point M;
     N_2=(double)(NB/2.0);
@@ -225,7 +225,7 @@ static bool init_MPE(int &i,int&j) {
 static  bool solve3(double M[3][3],double *b) {
   //renvoie true ou false si le systeme a une solution, ecrite dans b
   double D=0.0,x[3]={0,0,0},t[3];
-  register int i,j;
+  int i,j;
   
   D+=M[0][0]*(M[1][1]*M[2][2]-(M[2][1]*M[1][2]));
   D-=M[0][1]*(M[1][0]*M[2][2]-(M[2][0]*M[1][2]));
@@ -278,7 +278,7 @@ void   init_NFF(char * EnvName,double *Esource,double &Rsph,bool bias) {
 #endif
   //precalcul pour les dist. et les dFF
   int a;
-  register int i,ii,j,N_2;
+  int i,ii,j,N_2;
   double v2,u2;
 
   denv=Rsph;
@@ -735,7 +735,7 @@ void NFF(int i_sup,int i_inf,VEC **Cfar){
 void NFF(SPMAT*FF,int &i_sup,int &i_inf,VEC **Cfar){
 #endif
   //Rq : 'cause envt on ne peut pas profiter de Ai.Fij=Aj.Fji
-  register int i,j,n,idx;
+  int i,j,n,idx;
   //printf("NFF() : DEBUT\n");
   //Chrono
   time(&dTnff);
@@ -922,7 +922,7 @@ void stat_NFF() {
   printf("@ Temps total de NFF()        : %d:%d:%d (%ld s)\n\n",(int)(Tnff/3600),(int)((Tnff%3600)/60),(int)(Tnff%60),Tnff);
   fflush(stdout);
 #ifdef _HD
-  register int i;
+  int i;
   //Ecriture du fichier binaire diag.bzh
   FILE* diagb;
   Ferr<<"FF.cpp: stat_NFF(): file "<<pcDgName<<" open for writing\n"; 

--- a/src/cpp/Canestra/src/image.h
+++ b/src/cpp/Canestra/src/image.h
@@ -35,14 +35,14 @@ class Image {
         btm.alloue(img.btm.maxi()[0],img.btm.maxi()[1]);
 */
     cout<<"Image[=]  avant copie des variables de btm \n";cout.flush(); 
-       for(register int i=0;i<pim->btm.maxi()[0];i++)
-         for(register int j=0;j<pim->btm.maxi()[1];j++)
+       for(int i=0;i<pim->btm.maxi()[0];i++)
+         for(int j=0;j<pim->btm.maxi()[1];j++)
           pim-> btm(i,j)=   img.btm(i,j);
         return *pim;
       } 
    double maxval(){
      double val;
-     register int i,j;
+     int i,j;
      
      bitmax=-9.9e20;
      for(j=0;j<btm.maxi()[1];j++)
@@ -97,7 +97,7 @@ class Image {
         fic<<"# MONTE CARLO - MC - 08/1994 \n#      BitMax = "<<bitmax<<endl;
         fic<<btm.maxi()[0]<<" "<<btm.maxi()[1]<<endl;
         fic<<"255\n";
-        register int i,j;
+        int i,j;
         for(j=0;j<btm.maxi()[1];j++)
           for(i=0;i<btm.maxi()[0];i++) {
 	    pix= (unsigned char) (btm(i,j)/bitmax*255);
@@ -133,15 +133,15 @@ class RGB {
         btm.alloue(img.btm.maxi()[0],img.btm.maxi()[1]);
 */
     cout<<"RGB[=]  avant copie des variables de btm \n";cout.flush(); 
-       for(register int i=0;i<pim->btm.maxi()[0];i++)
-         for(register int j=0;j<pim->btm.maxi()[1];j++)
-	   for(register int k=0;k<3;k++)
+       for(int i=0;i<pim->btm.maxi()[0];i++)
+         for(int j=0;j<pim->btm.maxi()[1];j++)
+	   for(int k=0;k<3;k++)
           pim-> btm(i,j,k)=   img.btm(i,j,k);
         return *pim;
       } 
    double maxval(int k)
     { double val;
-      register int i,j;
+      int i,j;
     
       bitmax=-9.9e20;
       for(j=0;j<btm.maxi()[1];j++)
@@ -204,7 +204,7 @@ class RGB {
         fic<<"# class RGB - MC - 1996 \n#      BitMax = "<<bitmax<<endl;
         fic<<btm.maxi()[0]<<" "<<btm.maxi()[1]<<endl;
         fic<<"255\n";
-        register int i,j,k;
+        int i,j,k;
         for(j=0;j<btm.maxi()[1];j++)
           for(i=0;i<btm.maxi()[0];i++)
 	    for(k=0;k<3;k++) {

--- a/src/cpp/Canestra/src/image.h
+++ b/src/cpp/Canestra/src/image.h
@@ -21,11 +21,11 @@ class Image {
    char filename[80];
  public:
     Image(){}
-    Image(int x,int y,char * nom="out.ppm")
+    Image(int x,int y,char * nom=(char*)"out.ppm")
       {init(x, y,nom);}
 
     // typage AH 02 2001
-    void init(int x,int y,char * nom="out.ppm")
+    void init(int x,int y,char * nom=(char*)"out.ppm")
       { btm.alloue(x,y);strcpy(filename,nom);bitmax=-9.9e10;}
 
     Image & operator =(Image &img)
@@ -102,7 +102,7 @@ class Image {
           for(i=0;i<btm.maxi()[0];i++) {
 	    pix= (unsigned char) (btm(i,j)/bitmax*255);
 	    pix = (pix>=255)?255:pix;
-	    sprintf(ccTmp,"%ud", pix) ; 
+	    snprintf(ccTmp,sizeof(ccTmp),"%ud", pix) ; 
 	    fic.write(ccTmp,1);
 	  }      
         fic.close();
@@ -121,10 +121,10 @@ class RGB {
    char filename[80];
  public:
     RGB(){}
-    RGB(int x,int y,char * nom="out.ppm")
+    RGB(int x,int y,char * nom=(char*)"out.ppm")
       {init(x, y,nom);}
    // typage AH 02 2001 
-    void     init(int x,int y,char * nom="out.ppm")
+    void     init(int x,int y,char * nom=(char*)"out.ppm")
       { btm.alloue(x,y,3);strcpy(filename,nom);bitmax=-9.9e10;}
     RGB & operator =(RGB &img)
       { cout<<"RGB[=]  DEBUT \n";cout.flush();
@@ -184,13 +184,13 @@ class RGB {
      { btm.maj(val);bitmax=val;}
 
    // typage AH 02 2001 
-    void     charge(char *name=" ")
+    void     charge(char *name=(char*)" ")
       { if(!strcmp(name," ")) name=filename;
         cout<<"RGB[charge] Pas encore implemente !\n";
       }
 
    // typage AH 02 2001 
-    void     sauve(char *name=" ")
+    void     sauve(char *name=(char*)" ")
       { 
 	//unsigned char bit;
 	unsigned int pix ;
@@ -218,7 +218,7 @@ class RGB {
 		/*/
 	      pix= (unsigned int) (btm(i,j,k)/bitmax*255);
 	      pix=(pix>=255)?255:pix;
-	      sprintf(ccTmp,"%ud", pix) ; 
+	      snprintf(ccTmp,sizeof(ccTmp),"%ud", pix) ; 
 	      fic.write(ccTmp,1);  
 	      /**/
              }      

--- a/src/cpp/Canestra/src/infini.cpp
+++ b/src/cpp/Canestra/src/infini.cpp
@@ -30,7 +30,7 @@ void pave(int x,int  y, char idx) ;
 
 //local function
 bool out(int i,int j,int moving_i,int moving_j) {
-  register int k,l;
+  int k,l;
   bool dehors[2]={true,true};
 
 

--- a/src/cpp/Canestra/src/lumiere.cpp
+++ b/src/cpp/Canestra/src/lumiere.cpp
@@ -12,7 +12,7 @@ void Soleil :: init (int& n,Vecteur& dir, double* bmin, double* bmax){
   Vecteur V;
   dir.normalise();
   // cas d'un direction oblique
-  for(register int i=0;i<3;i++){
+  for(int i=0;i<3;i++){
     bornemin[i]=bmin[i];
     bornemax[i]=bmax[i];
   }
@@ -69,7 +69,7 @@ void SoleilSS :: init (int& n, Vecteur& dir, double* bmin, double* bmax){
   Vecteur V;
   dir.normalise();
   // cas d'un direction oblique
-  for(register int i=0;i<3;i++){
+  for(int i=0;i<3;i++){
     bornemin[i]=bmin[i];
     bornemax[i]=bmax[i];
   }

--- a/src/cpp/Canestra/src/radioxity.cpp
+++ b/src/cpp/Canestra/src/radioxity.cpp
@@ -885,7 +885,9 @@ int main(int argc,char **argv){
       snprintf(cmd,sizeof(cmd),"maxmem %s 1 > maxmem.res &",argv[0]);
       if(verbose)
 	Ferr <<"Option -T :  Pour avoir le max de memoire occupee = "<<cmd<<"\n";
-      system(cmd);
+      if (system(cmd) == -1) {
+		perror("Error executing system command");
+	  }
     }
     fflush(stdout); fflush(stderr); 
     //Fin Gestion des Options

--- a/src/cpp/Canestra/src/radioxity.cpp
+++ b/src/cpp/Canestra/src/radioxity.cpp
@@ -705,7 +705,7 @@ int main(int argc,char **argv){
       } else
 #ifndef WIN32
 	// Unix way
-	shmdt((void*)shmid2);
+	shmdt((void*)(size_t)shmid2);
 #else
       // Complicated Way
       UnmapViewOfFile(lpSharedSeg) ; // invalidation du ptr sur mem partagee
@@ -882,7 +882,7 @@ int main(int argc,char **argv){
       dirname= new char[100]; strcpy(dirname,".\\");}
     if(memsize){
       char cmd[125];
-      sprintf(cmd,"maxmem %s 1 > maxmem.res &",argv[0]);
+      snprintf(cmd,sizeof(cmd),"maxmem %s 1 > maxmem.res &",argv[0]);
       if(verbose)
 	Ferr <<"Option -T :  Pour avoir le max de memoire occupee = "<<cmd<<"\n";
       system(cmd);

--- a/src/cpp/Canestra/src/radioxity.cpp
+++ b/src/cpp/Canestra/src/radioxity.cpp
@@ -722,7 +722,7 @@ int main(int argc,char **argv){
   //======>  beep(): fait bip !
   inline void beep(const char *msg="M'enfin ...",int nbeep=1){
     cout<<(char) 7 <<msg<<endl;
-    for(register int i=1;i<1;i++) cout<<(char) 7<<endl;
+    for(int i=1;i<1;i++) cout<<(char) 7<<endl;
   }//beep()
 
   //======>  erreur_syntaxe(): imprime les options du prog a l'ecran

--- a/src/cpp/Canestra/src/solver.cpp
+++ b/src/cpp/Canestra/src/solver.cpp
@@ -164,12 +164,12 @@ void hd_mgcr(VEC *x,VEC *b, Diffuseur **TabDiff,double tol,int krylov,int limit,
   if (ip == INULL) error(E_NULL,(char*)"hd_mgcr");
   /* Ax, b and stopping criterion must be given */
   if (! ip->Ax || ! ip->b || ! ip->stop_crit) 
-    error(E_NULL,(char*)"hd_mgcr");
+    error(E_NULL,(const char*)"hd_mgcr");
   /* at least one direction vector must exist */
-  if ( ip->k <= 0) error(E_BOUNDS,(char*)"mgcr");
+  if ( ip->k <= 0) error(E_BOUNDS,(const char*)"mgcr");
   /* if the vector x is given then b and x must have the same dimension */
   if ( ip->x && ip->x->dim != ip->b->dim)
-    error(E_SIZES,(char*)"hd_mgcr");
+    error(E_SIZES,(const char*)"hd_mgcr");
   if (ip->eps <= 0.0) ip->eps = MACHEPS;
    
   dim = ip->b->dim;

--- a/src/cpp/Canestra/src/va_test.cpp
+++ b/src/cpp/Canestra/src/va_test.cpp
@@ -13,7 +13,7 @@ int f(int first, int second, int third,...){
   
   indice=first+10*second+100*third;
   va_start(ptarg,third);  
-  for(register unsigned char i=3;i<4;i++){
+  for(unsigned char i=3;i<4;i++){
     //indice+=coeff*bonind(va_arg(ptarg,int),i);
     indice+=1000*va_arg(ptarg,int);
   }   

--- a/src/cpp/Canestra/src/visu3d.cpp
+++ b/src/cpp/Canestra/src/visu3d.cpp
@@ -17,7 +17,7 @@
 
 inline void beep(const char *msg="M'enfin ...",int nbeep=1)
 { cout<<(char) 7 <<msg<<endl;
-  for(register int i=1;i<1;i++) cout<<(char) 7<<endl;
+  for(int i=1;i<1;i++) cout<<(char) 7<<endl;
 }//beep()
 
 #define PAUSE(msg)  printf(msg);printf("- Taper la touche Any");getchar();
@@ -32,7 +32,7 @@ void FileOk(char * nfic){
 }//FileOk()
 
 int main(int argc,char **argv){
-  register unsigned int i,j;
+  unsigned int i,j;
   // Gestion des options
   bool sol=false,infty=false, abs=false;
   double max=-1;
@@ -136,7 +136,7 @@ int main(int argc,char **argv){
      fG=fopen(nomG,"r");
      fB=fopen(nomB,"r");
   }
-  register int ii,im;
+  int ii,im;
   for(i=0;i<scene.radim;){
     im=(TabDiff[nbp]->isopaque())? 1: 2;
     for(ii=0;ii<im;ii++,i++){

--- a/src/cpp/Canestra/src/voxel.cpp
+++ b/src/cpp/Canestra/src/voxel.cpp
@@ -253,7 +253,7 @@ void Voxel::construction(reel* bornemin, reel* bornemax,
        <<" - ratio = "  << ratio<<"\n" ;
   }
   else {
-    fscanf(grille_par,"%d %g",&SEUIL_NB_DIFF,&ratio);
+    fscanf(grille_par,"%d %lg",&SEUIL_NB_DIFF,&ratio);
     Ferr <<"Seuil dans "  << grille_nom<<" = "  << SEUIL_NB_DIFF
        <<" - ratio = "  << ratio<<"\n" ;
     }

--- a/src/cpp/Canestra/src/voxel.cpp
+++ b/src/cpp/Canestra/src/voxel.cpp
@@ -41,7 +41,7 @@ Voxel::~Voxel(){
     // MC161203 : gestion a la mano des desallocation par un tableau de pointeur
     // NB une facon plus propre serait de gerer dans BSP un nbre d'instance
 
-    register int i,j,k,n; 
+    int i,j,k,n; 
     for(i=0;i<SI.maxi()[0];i++)
       for(j=0;j<SI.maxi()[1];j++)
 	for(k=0;k<SI.maxi()[2];k++){
@@ -82,7 +82,7 @@ Voxel& Voxel::operator = (Voxel& g){
 void  Voxel::division(char  axe, unsigned char * niveau_sub_max,BSP* B){
   BSP *B1;
   BSP *B2;
-  register int i;
+  int i;
   int indi;
   bool taille_min[3];
   double frontier;
@@ -216,7 +216,7 @@ void Voxel::numerotation(BSP* B){
 
 //************* Voxel:: visu()  ***********
 void Voxel::visu(){
-  register int i,j,k;
+  int i,j,k;
   BSP * B;
   
   Ferr <<"Voxel[visu()] DEBUT\n" ;
@@ -235,7 +235,7 @@ void Voxel::visu(){
 void Voxel::construction(reel* bornemin, reel* bornemax,
 			 double Renv, ListeD<Diffuseur*>& Ldiff) {
   double delta[3],reste,ratio=1.0 ;
-  register int i;
+  int i;
   FILE *grille_par;
   char grille_nom[]="grille_par";
   

--- a/src/cpp/Periodise/src/T_geometrie.cpp
+++ b/src/cpp/Periodise/src/T_geometrie.cpp
@@ -82,7 +82,7 @@ Homogene& Homogene::operator /= (double a){
 #ifdef _FUC
 Homogene Homogene::operator * (Matrice4& M){
   Homogene res;
-  register int i, j;
+   int i, j;
 
   for (i=0; i<3; i++)
     for (j=0; j<4; j++)
@@ -409,7 +409,7 @@ Homogene& Matrice4 :: operator [] (int i){
 }
 
 Matrice4& Matrice4 :: operator = (Matrice4& A){
-  register int i, j;
+   int i, j;
 
   for (i=0; i<4; i++)
     for (j=0; j<4; j++)

--- a/src/cpp/Periodise/src/T_geometrie.h
+++ b/src/cpp/Periodise/src/T_geometrie.h
@@ -182,7 +182,7 @@ int min3 (Type a, Type b, Type c)
 #ifdef _FUC
 inline Homogene Homogene::operator * (Matrice4& M){
   Homogene res;
-  register int i, j;
+  int i, j;
 
   for (i=0; i<3; i++)
     for (j=0; j<4; j++)

--- a/src/cpp/Periodise/src/T_utilitaires.h
+++ b/src/cpp/Periodise/src/T_utilitaires.h
@@ -70,7 +70,7 @@ private:  // fonction privee
 //************ operator = *****************
 template <class Type, unsigned int D>   
 inline Tabdyn<Type,D>& Tabdyn<Type,D>::operator =(Tabdyn<Type,D>& rval){
-  for(register unsigned char i=0;i<D ;i++)
+  for(unsigned char i=0;i<D ;i++)
     if(max[i]!=rval.max[i]){
       cerr<<"\n Tabdyn [operator =] erreur dimension "<<i<<endl;
       exit(-1);
@@ -119,7 +119,7 @@ template <class Type, unsigned int D>
 inline void  Tabdyn<Type,D>::lectarg ( int &first,va_list & ptarg ){
   // va_start(ptarg,first);
   taille=max[0]=bonmax(first);
-  for(register unsigned char  i=1;i<D;i++){
+  for(unsigned char  i=1;i<D;i++){
     max[i]=bonmax(va_arg(ptarg,int));
     taille*=max[i];
     // cout<<"taille"<< taille<<"\n";
@@ -190,7 +190,7 @@ Type & Tabdyn<Type,D>::operator()(int first, int second, int third,...){
   coeff=max[0]*max[1];
   indice=first+max[0]*second+coeff*third;
   va_start(ptarg,third);  
-  for(register unsigned char i=3;i<D;i++){
+  for(unsigned char i=3;i<D;i++){
     coeff*=max[i-1];
     //indice+=coeff*bonind(va_arg(ptarg,int),i);
     indice+=coeff*va_arg(ptarg,int);

--- a/src/cpp/Periodise/src/canopyL.cpp
+++ b/src/cpp/Periodise/src/canopyL.cpp
@@ -28,7 +28,7 @@ void Canopy::gencan(char *fname){
   FILE *fic;
   Diffuseur *diff;
   Primitive *prim;
-  register int i,nbs,nbd=0,nbp=0;
+  int i,nbs,nbd=0,nbp=0;
   int label;
 
   fic=fopen(fname,"w");
@@ -181,7 +181,7 @@ char* endline(ifstream & fin){
 
 void Canopy::parse_can(char *ngeom,char *nopti,reel *bornemin,reel*bornemax,bool sol,char *name8){
   bool rejet=false,infty=false;
-  register int i=0,nbp=0;
+  int i=0,nbp=0;
   Diffuseur* diff;
   ifstream fopti;
   char c, line[256];
@@ -290,7 +290,7 @@ void Canopy::parse_can(char *ngeom,char *nopti,reel *bornemin,reel*bornemax,bool
   double nom,espid;
   bool valid;
   reel min[3],max[3];
-  register int id;
+  int id;
   unsigned char specie; 
   bool opak;
   espid=1000000;

--- a/src/cpp/Periodise/src/diffuseur.cpp
+++ b/src/cpp/Periodise/src/diffuseur.cpp
@@ -143,7 +143,7 @@ Param_Inter DiffO::interact(Param_Inter &parag,bool inside,int order){
   v=rediff;
   w=prim->normal();
   u=v.prod_vectoriel(w);
-  for(register int i=0;i<3;i++){
+  for(int i=0;i<3;i++){
     rediff[i]= u[i]*n[0] + v[i]*n[1] + w[i]*n[2] ;
   }
   
@@ -388,7 +388,7 @@ void DiffO::calc_stat(int niter, double Stoit){
 //-*************** DiffT::norm_surf() ************************
 
 void DiffT::norm_surf(int nbr,double Stoit){
-  //MC00: ???? pourquoi seult la moyenne est normalisée??
+  //MC00: ???? pourquoi seult la moyenne est normalisï¿½e??
   // calcul de la moyenne et de la variance
   double surf;
   
@@ -431,7 +431,7 @@ void DiffO::norm_surf(int nbr,double Stoit){
 
 //-*************** Diff8::cstructor *****************************
 Diff8::Diff8(Diffuseur * pdif,Vecteur & delta) {
-  register int i;
+  int i;
   
   diff=pdif;
   prim=new Polygone(*((Polygone*)&(diff->primi())));

--- a/src/cpp/Periodise/src/primitive.cpp
+++ b/src/cpp/Periodise/src/primitive.cpp
@@ -77,7 +77,7 @@ char * next_nonumber(char *ch){
 
 Polygone::Polygone(char* line,double name,reel*mini,reel*maxi){
   //  istrstream Lparag(line);
-  register int i,j;
+  int i,j;
   int ii;
   Point P;
   char *ch;
@@ -163,7 +163,7 @@ Polygone::Polygone(char* line,double name,reel*mini,reel*maxi){
 }//Polygone
 
 Polygone::Polygone(float(*T)[3],double name,reel*mini,reel*maxi){
-  register int i,j;
+  int i,j;
   Point P;
   double x;
 
@@ -237,7 +237,7 @@ Polygone::Polygone(float(*T)[3],double name,reel*mini,reel*maxi){
 
 void Polygone::show(const char* msg,ostream &out)
 {   out << msg<<"-Polygone :"; qui();
-for (register int i=0; i<nb_sommets; i++)
+for (int i=0; i<nb_sommets; i++)
 	{ out << "\t" <<sommet[i][0]<<" "<<sommet[i][1]<<" "<<sommet[i][2]<<endl;
 
 	}
@@ -295,7 +295,7 @@ int Polygone::tout_point_sup(reel& position, char& axe){
 }
 
 int Polygone::nb_in(reel& amin,reel& amax, char& axe) {
-  register int nbp=0,i;
+  int nbp=0,i;
   bool info=false;
   for (i=0; i<nb_sommets; i++) {
     if(sommet[i][axe]>amax) {
@@ -347,7 +347,7 @@ void Polygone::calcul_normale_cst_equ(Point& p1, Point& p2, Point& p3){
 }
 
 Point  Polygone::centre(){
-  register int i,j;
+  int i,j;
   Point G(0,0,0);
 
   for(i=0;i<nb_sommets;i++)
@@ -492,7 +492,7 @@ void Polygone::calc_surface(){
   default:
     Point G=centre();
     psurf=0.0;
-    for(register int i=0;i<nb_sommets;){
+    for(int i=0;i<nb_sommets;){
       u.formation_vecteur(G,sommet[i++]);
       v.formation_vecteur(G,sommet[(i<nb_sommets)?i:0]);
       psurf+=(u.prod_vectoriel(v)).norme();

--- a/src/cpp/bibliotek/T_geometrie.cpp
+++ b/src/cpp/bibliotek/T_geometrie.cpp
@@ -76,7 +76,7 @@ Homogene& Homogene::operator /= (const double& a){
 #ifdef _FUC
 Homogene Homogene::operator * (Matrice4& M){
   Homogene res;
-  register int i, j;
+  int i, j;
 
   for (i=0; i<3; i++)
     for (j=0; j<4; j++)
@@ -86,7 +86,7 @@ Homogene Homogene::operator * (Matrice4& M){
 }
 #endif
 Homogene  Homogene::chgt_base(const Vecteur &u, const Vecteur &v, const Vecteur &w) const{
-  register int i;
+  int i;
   Homogene tmp;
 
   tmp[0]=u[0]*homo[0]+u[1]*homo[1]+u[2]*homo[2];
@@ -385,7 +385,7 @@ Homogene& Matrice4 :: operator [] (int i){
 }
 
 Matrice4& Matrice4 :: operator = (Matrice4& A){
-  register int i, j;
+  int i, j;
 
   for (i=0; i<4; i++)
     for (j=0; j<4; j++)

--- a/src/cpp/bibliotek/parse_geometry.cpp
+++ b/src/cpp/bibliotek/parse_geometry.cpp
@@ -119,7 +119,7 @@ void SetTurtle(TURTLE *tu){
 /*************************************************************************/
 /* draws triangles */
 void OGLPrim::DrawTriangle(float *p1, float *p2, float *p3){
-  register short i;
+  short i;
   float u[3],v[3],w[3],Gt[3],surf;
   
   for(i=0;i<3;i++){
@@ -516,7 +516,7 @@ int OGLPrim::parse_line(char *line)
 {
 //line <= CSGetString(), T[nbT] return the triangles describing the analysed primitive
 struct syntax_item *ptr;
-register int i=0,ir=0;
+int i=0,ir=0;
 char real[500],c,*str=NULL;
 short record=0,lstr;
 int answer=0;

--- a/src/cpp/bibliotek/primitive.cpp
+++ b/src/cpp/bibliotek/primitive.cpp
@@ -14,7 +14,7 @@ Primitive :: Primitive(Point p)
 // POLYGONE
 
 void Polygone::init(Liste<Point>& liste_sommet,double name=0){
-  register int i=1;
+  int i=1;
   
   nom=name;
   for( liste_sommet.debut();
@@ -36,7 +36,7 @@ void Polygone::init(Liste<Point>& liste_sommet,double name=0){
 }//init
 
 Polygone::Polygone( Polygone& frere):Primitive(){
-  register int i;
+  int i;
   nb_sommets=i=frere.nb_sommet();
   printf("Polygone::Polygone(Polygone&) nb_sommets=%d\n",i);fflush(stdout);
   sommet=new Point[i];
@@ -46,7 +46,7 @@ Polygone::Polygone( Polygone& frere):Primitive(){
   calcul_normale_cst_equ(sommet[0],sommet [1],sommet[2]);
 }//Cstructeur par copie
 Polygone::Polygone(Polygone* frere){
-  register int i;
+  int i;
   
   nb_sommets=i=frere->nb_sommet();
   sommet=new Point[i];
@@ -224,7 +224,7 @@ Ferr <<"\tPolygone::init(char*) => Norme de (POP1)^(POP2 Nulle \n" ;
 }//Polygone::init(char*) 
 
 Polygone::Polygone(float(*T)[3],double name,reel*mini,reel*maxi){
-  register int i,j;
+  int i,j;
   int ii;
   Point P;
   double x;
@@ -292,7 +292,7 @@ Ferr <<"\tPolygone(reel **) => Norme de (POP1)^(POP2 Nulle \n" ;
 
 void Polygone::show(const char* msg,ostream &out){
   out << msg<<"-Polygone :"; qui();
-  for (register int i=0; i<nb_sommets; i++){
+  for (int i=0; i<nb_sommets; i++){
     out << "\t" <<sommet[i][0]<<" "<<sommet[i][1]<<" "<<sommet[i][2]<<endl;
   }
 }//show()
@@ -353,7 +353,7 @@ int Polygone::tout_point_sup(reel& position, const int& axe){
 }
 
 int Polygone::nb_in(reel& amin,reel& amax, const int& axe) {
-  register int nbp=0,i;
+  int nbp=0,i;
   bool info=false;
   for (i=0; i<nb_sommets; i++) {
     if(sommet[i][axe]>amax) {
@@ -403,7 +403,7 @@ void Polygone::calcul_normale_cst_equ(Point& p1, Point& p2, Point& p3){
   OA.formation_vecteur(O,p1);
   cst_equ_plan=OA.prod_scalaire(normale);
   //Calcul de l'isobarycentre et de la + grde distance de isob aux sommets (aprt_sphere)
-  register int i,j;
+  int i,j;
   float d2;
   isob[0]=isob[1]=isob[2]=0.;
   for(i=0;i<nb_sommets;i++)
@@ -552,7 +552,7 @@ double Polygone::surface(){
   default:
     Point G=centre();
     x=0.0;
-    for(register int i=0;i<nb_sommets;){
+    for(int i=0;i<nb_sommets;){
       u.formation_vecteur(G,sommet[i++]);
       v.formation_vecteur(G,sommet[(i<nb_sommets)?i:0]);
       x+=(u.prod_vectoriel(v)).norme();

--- a/src/cpp/bibliotek/primitive.cpp
+++ b/src/cpp/bibliotek/primitive.cpp
@@ -116,7 +116,7 @@ void Polygone::init(char* line,double name,
   nom=name;
   strcpy(str3,line);
   sscanf(str3,"%d",&ii);
-  sprintf(str2,"%d",ii);
+  snprintf(str2,sizeof(str2), "%d",ii);
   str=strstr(str3,str2);//strtok(str3,str2);
   str++;
   nb_sommets=i=ii;

--- a/src/cpp/include/T_geometrie.h
+++ b/src/cpp/include/T_geometrie.h
@@ -193,7 +193,7 @@ int min3 (Type a, Type b, Type c)
 #ifdef _FUC
 inline Homogene Homogene::operator * (Matrice4& M){
   Homogene res;
-  register int i, j;
+  int i, j;
 
   for (i=0; i<3; i++)
     for (j=0; j<4; j++)
@@ -203,7 +203,7 @@ inline Homogene Homogene::operator * (Matrice4& M){
 }
 #endif
 inline Homogene Homogene::chgt_base(const Vecteur &u, const Vecteur &v, const Vecteur &w) const{
-  register int i;
+  int i;
   Homogene tmp;
 
   tmp[0]=u[0]*homo[0]+u[1]*homo[1]+u[2]*homo[2];

--- a/src/cpp/include/T_utilitaires.h
+++ b/src/cpp/include/T_utilitaires.h
@@ -73,7 +73,7 @@ private:  // fonction privee
 //************ operator = *****************
 template <class Type, unsigned int D>   
 inline Tabdyn<Type,D>& Tabdyn<Type,D>::operator =(Tabdyn<Type,D>& rval){
-  for(register unsigned char i=0;i<D ;i++)
+  for(unsigned char i=0;i<D ;i++)
     if(max[i]!=rval.max[i]){
       Ferr<<"\n Tabdyn [operator =] erreur dimension "<<i<<'\n' ;
       exit(35);
@@ -123,7 +123,7 @@ template <class Type, unsigned int D>
 inline void  Tabdyn<Type,D>::lectarg ( int &first,va_list & ptarg ){
   // va_start(ptarg,first);
   taille=max[0]=bonmax(first);
-  for(register unsigned char  i=1;i<D;i++){
+  for(unsigned char  i=1;i<D;i++){
     max[i]=bonmax(va_arg(ptarg,int));
     taille*=max[i];
     // cout<<"taille"<< taille<<"\n";
@@ -197,7 +197,7 @@ Type & Tabdyn<Type,D>::operator()(int first, int second, int third,...){
   coeff=max[0]*max[1];
   indice=first+max[0]*second+coeff*third;
   va_start(ptarg,third);  
-  for(register unsigned char i=3;i<D;i++){
+  for(unsigned char i=3;i<D;i++){
     coeff*=max[i-1];
     //indice+=coeff*bonind(va_arg(ptarg,int),i);
     indice+=coeff*va_arg(ptarg,int);

--- a/src/cpp/include/diffuseur.h
+++ b/src/cpp/include/diffuseur.h
@@ -27,7 +27,7 @@ public:
   virtual bool isreal()=0;
   double intersect(Param_Inter parag,Point *I)
   {return (prim->intersect(parag,I));}
-  void  show(char *texte="",ostream& out=cout) // montre!
+  void  show(char *texte=(char *)"",ostream& out=cout) // montre!
   { prim->show(texte,out);  }
   virtual  unsigned int num()=0;
   virtual  void togle_face()=0;

--- a/src/cpp/mc-sail/src/msail.cpp
+++ b/src/cpp/mc-sail/src/msail.cpp
@@ -1,7 +1,7 @@
 
 #define _Msail
 
-#include <iostream> // définit des namespaces
+#include <iostream> // dï¿½finit des namespaces
 using namespace std ;
 
 #include "multicou.h"
@@ -34,7 +34,7 @@ void distrib(double *,double,double);
    sous-programme DISTRIB.                                                  
 *************************************************************************/
 void msailad(Msailin &msailin){
-  register int ia,ic,ili;
+  int ia,ic,ili;
   REEL fcum, sbfs, cstl, psir, tsin, sntl, cs2tl, sn2tl;
   REEL cspsi, tanto, tants, t1, btran1, btran2;
   REEL bt1, bt2, bt3, sw1, sw2, sbf;
@@ -286,7 +286,7 @@ void mlayer(Msailin &msailin, Mlayout* Tlayout){
    *************************************************************************/
 void distrib(double *fbeta,double u,double v){
   static double freq, gamm1, gamm2, gamm3, part1, part2, part3;
-  register  int ili,i;
+   int ili,i;
   static double w,y1, y2, y3, dif, gam, ang, pie;
   static double pon, sum;
 

--- a/src/cpp/mc-sail/src/multicou.cpp
+++ b/src/cpp/mc-sail/src/multicou.cpp
@@ -19,7 +19,7 @@ ferrlog Ferr((char*)"mc-sail.log") ;
 int main(int argc, char **argv){
   double clai, ctau, croo, sf, dz, hau, ros;
   int id,npo;
-  register int i,j;
+  int i,j;
   FILE *fpar, *fout, *fenv, *fpvf ;
   ifstream fpar2;
   char line[200];

--- a/src/cpp/mc-sail/src/multicou.h
+++ b/src/cpp/mc-sail/src/multicou.h
@@ -31,7 +31,7 @@ struct Msailin{
   Msailin(){nbang=-1;tts=tto=psi=0;}
   void alloue(int n){
     n++;
-    register int i;
+    int i;
     if(nbang>0){
       l=new REEL[n];   ttl=new REEL[n];
       roo=new REEL[n]; tau=new REEL[n];
@@ -49,7 +49,7 @@ struct Msailin{
     if (nbang >0) {
       delete [] l;delete [] ttl;delete [] roo;
       delete [] tau;delete [] bmu;delete [] bnu ;
-    } // sinon plante à vide
+    } // sinon plante ï¿½ vide
   }//destructor
 } ;
 struct Limit{

--- a/src/cpp/mc-sail/src/profil.cpp
+++ b/src/cpp/mc-sail/src/profil.cpp
@@ -1,6 +1,6 @@
 #define _Mprof
 
-#include <iostream> // définit des namespaces
+#include <iostream> // dï¿½finit des namespaces
 using namespace std ;
 
 #include "multicou.h"
@@ -18,7 +18,7 @@ struct Coeff{
 };
 
 void mprofil(Limit& limit,Profout* Tprof,Mlayout* Tlay){
-  register int ic;
+  int ic;
   Coeff *T,*o;
   Mlayout l;
   

--- a/src/cpp/meschach/mesch12a/include/err.h
+++ b/src/cpp/meschach/mesch12a/include/err.h
@@ -70,7 +70,7 @@ extern  int err_list_free(int list_num);   /* freeing a list of errors */
 
 
 /* error(E_TYPE,"myfunc") raises error type E_TYPE for function my_func() */
-#define	error(err_num,fn_name)	ev_err(__FILE__,err_num,__LINE__,fn_name,0)
+#define	error(err_num,fn_name)	ev_err((char *)__FILE__,err_num,__LINE__,(char *)fn_name,0)
 
 /* warning(WARN_TYPE,"myfunc") raises warning type WARN_TYPE for 
    function my_func() */

--- a/src/cpp/meschach/mesch12a/include/err.h
+++ b/src/cpp/meschach/mesch12a/include/err.h
@@ -56,7 +56,7 @@ extern  int err_list_free();		/* freeing a list of errors */
 
 #else  /* ANSI_C */
 
-extern	int ev_err(char *,int,int,char *,int);  /* main error handler */
+extern	int ev_err(char *,int,int,const char *,int);  /* main error handler */
 extern	int set_err_flag(int flag);         /* for different ways of handling
                                                 errors, returns old value */
 extern  int count_errs(int true_false);     /* to avoid "too many errors" */

--- a/src/cpp/meschach/mesch12a/src/Archie/zmachine.c
+++ b/src/cpp/meschach/mesch12a/src/Archie/zmachine.c
@@ -115,7 +115,7 @@ int	flag, len;
 /* __zmlt__ scalar complex multiply array c.f. sv_mlt() */
 void	__zmlt__(zp,s,out,len)
 Mcomplex	*zp, s, *out;
-register int	len;
+int	len;
 {
     int		i;
     LongReal	t_re, t_im;

--- a/src/cpp/meschach/mesch12a/src/conjgrad.c
+++ b/src/cpp/meschach/mesch12a/src/conjgrad.c
@@ -70,8 +70,8 @@ VEC	*spCHsolve();
 /* cg_set_maxiter -- sets maximum number of iterations if numiter > 1
 	-- just returns current max_iter otherwise
 	-- returns old maximum */
-int	cg_set_maxiter(numiter)
-int	numiter;
+int	cg_set_maxiter(int numiter)
+//int	numiter;
 {
 	int	temp;
 
@@ -86,11 +86,11 @@ int	numiter;
 /* pccg -- solves A.x = b using pre-conditioner M
 			(assumed factored a la spCHfctr())
 	-- results are stored in x (if x != NULL), which is returned */
-VEC	*pccg(A,A_params,M_inv,M_params,b,eps,x)
-MTX_FN	A, M_inv;
-VEC	*b, *x;
-double	eps;
-void	*A_params, *M_params;
+VEC	*pccg(MTX_FN A, void* A_params, MTX_FN M_inv, void* M_params, VEC* b, double eps, VEC* x)
+//MTX_FN	A, M_inv;
+//VEC	*b, *x;
+//double	eps;
+//void	*A_params, *M_params;
 {
 	VEC	*r = VNULL, *p = VNULL, *q = VNULL, *z = VNULL;
 	int	k;
@@ -156,10 +156,10 @@ void	*A_params, *M_params;
 		data structures
 	-- assumes that LLT contains the Cholesky factorisation of the
 		actual pre-conditioner */
-VEC	*sp_pccg(A,LLT,b,eps,x)
-SPMAT	*A, *LLT;
-VEC	*b, *x;
-double	eps;
+VEC	*sp_pccg(SPMAT* A, SPMAT* LLT, VEC* b, double eps, VEC* x)
+//SPMAT	*A, *LLT;
+//VEC	*b, *x;
+//double	eps;
 {	return pccg(sp_mv_mlt,A,spCHsolve,LLT,b,eps,x);		}
 
 
@@ -175,12 +175,12 @@ double	eps;
 		A is passed where A(x,Ax,params) computes
 		Ax = A.x
 	-- the computed solution is passed */
-VEC	*cgs(A,A_params,b,r0,tol,x)
-MTX_FN	A;
-VEC	*x, *b;
-VEC	*r0;		/* tilde r0 parameter -- should be random??? */
-double	tol;		/* error tolerance used */
-void	*A_params;
+VEC	*cgs(MTX_FN A, void* A_params, VEC* b, VEC* r0, double tol, VEC* x)
+//MTX_FN	A;
+//VEC	*x, *b;
+//VEC	*r0;		/* tilde r0 parameter -- should be random??? */
+//double	tol;		/* error tolerance used */
+//void	*A_params;
 {
 	VEC	*p, *q, *r, *u, *v, *tmp1, *tmp2;
 	Real	alpha, beta, norm_b, rho, old_rho, sigma;
@@ -246,10 +246,10 @@ void	*A_params;
 }
 
 /* sp_cgs -- simple interface for SPMAT data structures */
-VEC	*sp_cgs(A,b,r0,tol,x)
-SPMAT	*A;
-VEC	*b, *r0, *x;
-double	tol;
+VEC	*sp_cgs(SPMAT* A, VEC* b, VEC* r0, double tol, VEC* x)
+//SPMAT	*A;
+//VEC	*b, *r0, *x;
+//double	tol;
 {	return cgs(sp_mv_mlt,A,b,r0,tol,x);	}
 
 /*
@@ -262,11 +262,11 @@ double	tol;
 /* lsqr -- sparse CG-like least squares routine:
 	-- finds min_x ||A.x-b||_2 using A defined through A & AT
 	-- returns x (if x != NULL) */
-VEC	*lsqr(A,AT,A_params,b,tol,x)
-MTX_FN	A, AT;	/* AT is A transposed */
-VEC	*x, *b;
-double	tol;		/* error tolerance used */
-void	*A_params;
+VEC	*lsqr(MTX_FN A, MTX_FN AT, void* A_params, VEC* b, double tol, VEC* x)
+//MTX_FN	A, AT;	/* AT is A transposed */
+//VEC	*x, *b;
+//double	tol;		/* error tolerance used */
+//void	*A_params;
 {
 	VEC	*u, *v, *w, *tmp;
 	Real	alpha, beta, norm_b, phi, phi_bar,
@@ -342,9 +342,9 @@ void	*A_params;
 }
 
 /* sp_lsqr -- simple interface for SPMAT data structures */
-VEC	*sp_lsqr(A,b,tol,x)
-SPMAT	*A;
-VEC	*b, *x;
-double	tol;
+VEC	*sp_lsqr(SPMAT* A, VEC* b, double tol, VEC* x)
+//SPMAT	*A;
+//VEC	*b, *x;
+//double	tol;
 {	return lsqr(sp_mv_mlt,sp_vm_mlt,A,b,tol,x);	}
 

--- a/src/cpp/meschach/mesch12a/src/extras.c
+++ b/src/cpp/meschach/mesch12a/src/extras.c
@@ -97,7 +97,7 @@ int	len;
 double	alpha;
 Real	*x;
 {
-    register int	i;
+    int	i;
 
     for ( i = 0; i < len; i++ )
 	x[i] *= alpha;
@@ -108,8 +108,8 @@ void	Mswap(len,x,y)
 int	len;
 Real	*x, *y;
 {
-    register int	i;
-    register Real	tmp;
+    int	i;
+    Real	tmp;
 
     for ( i = 0; i < len; i++ )
     {
@@ -124,7 +124,7 @@ void	Mcopy(len,x,y)
 int	len;
 Real	*x, *y;
 {
-    register int	i;
+    int	i;
 
     for ( i = 0; i < len; i++ )
 	y[i] = x[i];
@@ -136,7 +136,7 @@ int	len;
 double	alpha;
 Real	*x, *y;
 {
-    register int	i, len4;
+    int	i, len4;
 
     /****************************************
     for ( i = 0; i < len; i++ )
@@ -164,15 +164,15 @@ double	Mdot(len,x,y)
 int	len;
 Real	*x, *y;
 {
-    register int	i, len4;
-    register Real	sum;
+    int	i, len4;
+    Real	sum;
 
 #ifndef REGISTER_RICH
     sum = 0.0;
 #endif
 
 #ifdef REGISTER_RICH
-    register Real	sum0, sum1, sum2, sum3;
+    Real	sum0, sum1, sum2, sum3;
     
     sum0 = sum1 = sum2 = sum3 = 0.0;
     
@@ -205,8 +205,8 @@ double	Mnorminf(len,x)
 int	len;
 Real	*x;
 {
-    register int	i;
-    register Real	tmp, max_val;
+    int	i;
+    Real	tmp, max_val;
 
     max_val = 0.0;
     for ( i = 0; i < len; i++ )
@@ -224,8 +224,8 @@ double	Mnorm1(len,x)
 int	len;
 Real	*x;
 {
-    register int	i;
-    register Real	sum;
+    int	i;
+    Real	sum;
 
     sum = 0.0;
     for ( i = 0; i < len; i++ )
@@ -239,8 +239,8 @@ double	Mnorm2(len,x)
 int	len;
 Real	*x;
 {
-    register int	i;
-    register Real	norm, invnorm, sum, tmp;
+    int	i;
+    Real	norm, invnorm, sum, tmp;
 
     norm = Mnorminf(len,x);
     if ( norm == 0.0 )
@@ -264,9 +264,9 @@ int	m, n, j0;
 double	alpha, beta;
 Real	**A, *x, *y;
 {
-    register int	i, j, m4, n4;
-    register Real	sum0, sum1, sum2, sum3, tmp0, tmp1, tmp2, tmp3;
-    register Real	*dp0, *dp1, *dp2, *dp3;
+    int	i, j, m4, n4;
+    Real	sum0, sum1, sum2, sum3, tmp0, tmp1, tmp2, tmp3;
+    Real	*dp0, *dp1, *dp2, *dp3;
 
     /****************************************
     for ( i = 0; i < m; i++ )
@@ -328,14 +328,14 @@ int	m, n, j0;
 double	alpha, beta;
 Real	**A, *x, *y;
 {
-    register int	i, j, m4, n2;
-    register Real	*Aref;
-    register Real 	tmp;
+    int	i, j, m4, n2;
+    Real	*Aref;
+    Real 	tmp;
 
 #ifdef REGISTER_RICH
-    register Real	*Aref0, *Aref1;
-    register Real	tmp0, tmp1;
-    register Real	yval0, yval1, yval2, yval3;
+    Real	*Aref0, *Aref1;
+    Real	tmp0, tmp1;
+    Real	yval0, yval1, yval2, yval3;
 #endif
 
     if ( beta != 1.0 )
@@ -398,9 +398,9 @@ int	m, n, j0;
 double	alpha;
 Real	**A, *x, *y;
 {
-    register int	i, j, n4;
-    register Real	*Aref;
-    register Real 	tmp;
+    int	i, j, n4;
+    Real	*Aref;
+    Real 	tmp;
 
     /****************************************
     for ( i = 0; i < m; i++ )
@@ -435,8 +435,8 @@ double  alpha;
 Real	**A, **B, **C;
 int	Aj0, Bj0, Cj0;
 {
-    register int	i, j, k;
-    /* register Real	tmp, sum; */
+    int	i, j, k;
+    /* Real	tmp, sum; */
 
     /****************************************
     for ( i = 0; i < m; i++ )
@@ -454,7 +454,7 @@ double  alpha;
 Real	**A, **B, **C;
 int	Aj0, Bj0, Cj0;
 {
-    register int	i, j, k;
+    int	i, j, k;
 
     /****************************************
     for ( i = 0; i < m; i++ )
@@ -472,7 +472,7 @@ double  alpha;
 Real	**A, **B, **C;
 int	Aj0, Bj0, Cj0;
 {
-    register int	i, j, k;
+    int	i, j, k;
 
     /****************************************
     for ( i = 0; i < m; i++ )
@@ -490,7 +490,7 @@ double  alpha;
 Real	**A, **B, **C;
 int	Aj0, Bj0, Cj0;
 {
-    register int	i, j, k;
+    int	i, j, k;
 
     for ( i = 0; i < m; i++ )
 	for ( j = 0; j < n; j++ )

--- a/src/cpp/meschach/mesch12a/src/iter0.c
+++ b/src/cpp/meschach/mesch12a/src/iter0.c
@@ -46,10 +46,7 @@ static char rcsid[] = "$Id: iter0.c,v 1.3 1995/01/30 14:50:56 des Exp $";
 /* standard functions */
 
 /* standard information */
-void iter_std_info(ip,nres,res,Bres)
-ITER *ip;
-double nres;
-VEC *res, *Bres;
+void iter_std_info(ITER* ip, double nres, VEC* res, VEC* Bres)
 {
    if (nres >= 0.0)
      printf(" %d. residual = %g\n",ip->steps,nres);
@@ -59,10 +56,7 @@ VEC *res, *Bres;
 }
 
 /* standard stopping criterion */
-int iter_std_stop_crit(ip, nres, res, Bres)
-ITER *ip;
-double nres;
-VEC *res, *Bres;
+int iter_std_stop_crit(ITER* ip, double nres, VEC* res, VEC* Bres)
 {
    /* standard stopping criterium */
    if (nres <= ip->init_res*ip->eps) return TRUE; 
@@ -72,8 +66,7 @@ VEC *res, *Bres;
 
 /* iter_get - create a new structure pointing to ITER */
 
-ITER *iter_get(lenb, lenx)
-int lenb, lenx;
+ITER *iter_get(int lenb, int lenx)
 {
    ITER *ip;
 
@@ -114,8 +107,7 @@ int lenb, lenx;
 
 
 /* iter_free - release memory */
-int iter_free(ip)
-ITER *ip;
+int iter_free(ITER* ip)
 {
    if (ip == (ITER *)NULL) return -1;
    
@@ -132,9 +124,7 @@ ITER *ip;
    return 0;
 }
 
-ITER *iter_resize(ip,new_lenb,new_lenx)
-ITER *ip;
-int new_lenb, new_lenx;
+ITER *iter_resize(ITER* ip,int new_lenb, int new_lenx)
 {
    VEC *old;
 
@@ -155,9 +145,7 @@ int new_lenb, new_lenx;
 
 
 /* print out ip structure - for diagnostic purposes mainly */
-void iter_dump(fp,ip)
-ITER *ip;
-FILE *fp;
+void iter_dump(FILE* fp, ITER* ip)
 {
    if (ip == NULL) {
       fprintf(fp," ITER structure: NULL\n");
@@ -186,8 +174,7 @@ FILE *fp;
    if ip2 == NULL then a new structure is created with x and b being NULL
    and other members are taken from ip1
 */
-ITER *iter_copy2(ip1,ip2)
-ITER *ip1, *ip2;
+ITER* iter_copy2(ITER* ip1, ITER* ip2)
 {
    VEC *x, *b;
    int shx, shb;
@@ -221,8 +208,7 @@ ITER *ip1, *ip2;
 
 
 /* copy the structure ip1 to ip2 copying also the vectors x and b */
-ITER *iter_copy(ip1,ip2)
-ITER *ip1, *ip2;
+ITER *iter_copy(ITER * ip1,ITER * ip2)
 {
    VEC *x, *b;
 
@@ -260,8 +246,7 @@ ITER *ip1, *ip2;
    n x n matrix, 
    nrow - number of nonzero entries in a row
    */
-SPMAT	*iter_gen_sym(n,nrow)
-int	n, nrow;
+SPMAT	*iter_gen_sym(int n, int nrow)
 {
    SPMAT	*A;
    VEC	        *u;
@@ -301,9 +286,7 @@ int	n, nrow;
    diag - number which is put in diagonal entries and then permuted
    (if diag is zero then 1.0 is there)
 */
-SPMAT	*iter_gen_nonsym(m,n,nrow,diag)
-int	m, n, nrow;
-double diag;
+SPMAT	*iter_gen_nonsym(int m, int n, int nrow, double diag)
 {
    SPMAT	*A;
    PERM		*px;
@@ -343,8 +326,7 @@ double diag;
    n x n sparse matrix;
    nrow - number of entries in a row
 */
-SPMAT	*iter_gen_nonsym_posdef(n,nrow)
-int	n, nrow;
+SPMAT	*iter_gen_nonsym_posdef(int n, int nrow)
 {
    SPMAT	*A;
    PERM		*px;

--- a/src/cpp/meschach/mesch12a/src/ivecop.c
+++ b/src/cpp/meschach/mesch12a/src/ivecop.c
@@ -335,7 +335,7 @@ IVEC*iv;
       return;
    }
    fprintf(fp,"dim: %d, max_dim: %d\n",iv->dim,iv->max_dim);
-   fprintf(fp,"ive @ 0x%lx\n",(long)(iv->ive));
+   fprintf(fp,"ive @ 0x%p\n",(size_t)(iv->ive));
    for ( i = 0; i < iv->max_dim; i++ )
    {
       if ( (i+1) % 8 )

--- a/src/cpp/meschach/mesch12a/src/ivecop.c
+++ b/src/cpp/meschach/mesch12a/src/ivecop.c
@@ -335,7 +335,7 @@ IVEC*iv;
       return;
    }
    fprintf(fp,"dim: %d, max_dim: %d\n",iv->dim,iv->max_dim);
-   fprintf(fp,"ive @ 0x%p\n",(size_t)(iv->ive));
+   fprintf(fp,"ive @ 0x%p\n",(void *)(iv->ive));
    for ( i = 0; i < iv->max_dim; i++ )
    {
       if ( (i+1) % 8 )

--- a/src/cpp/meschach/mesch12a/src/machine.c
+++ b/src/cpp/meschach/mesch12a/src/machine.c
@@ -36,9 +36,7 @@ static	char	*rcsid = "$Id: machine.c,v 1.4 1994/01/13 05:28:56 des Exp $";
 #include	"machine.h"
 
 /* __ip__ -- inner product */
-double	__ip__(dp1,dp2,len)
- Real	*dp1, *dp2;
-int	len;
+double	__ip__(Real *dp1, Real *dp2, int len)
 {
 #ifdef VUNROLL
      int	len4;
@@ -72,10 +70,7 @@ int	len;
 }
 
 /* __mltadd__ -- scalar multiply and add c.f. v_mltadd() */
-void	__mltadd__(dp1,dp2,s,len)
- Real	*dp1, *dp2;
- double s;
- int	len;
+void	__mltadd__(Real *dp1, Real *dp2, double s, int len)
 {
      int	i;
 #ifdef VUNROLL
@@ -98,10 +93,7 @@ void	__mltadd__(dp1,dp2,s,len)
 }
 
 /* __smlt__ scalar multiply array c.f. sv_mlt() */
-void	__smlt__(dp,s,out,len)
- Real	*dp, *out;
- double s;
- int	len;
+void	__smlt__(Real *dp, double s, Real *out,int len)
 {
      int	i;
     for ( i = 0; i < len; i++ )
@@ -109,9 +101,7 @@ void	__smlt__(dp,s,out,len)
 }
 
 /* __add__ -- add arrays c.f. v_add() */
-void	__add__(dp1,dp2,out,len)
- Real	*dp1, *dp2, *out;
- int	len;
+void	__add__(Real *dp1, Real *dp2, Real *out, int len)
 {
      int	i;
     for ( i = 0; i < len; i++ )
@@ -119,9 +109,8 @@ void	__add__(dp1,dp2,out,len)
 }
 
 /* __sub__ -- subtract arrays c.f. v_sub() */
-void	__sub__(dp1,dp2,out,len)
- Real	*dp1, *dp2, *out;
- int	len;
+void	__sub__(Real *dp1, Real *dp2, Real *out, int len)
+
 {
      int	i;
     for ( i = 0; i < len; i++ )
@@ -129,9 +118,7 @@ void	__sub__(dp1,dp2,out,len)
 }
 
 /* __zero__ -- zeros an array of floating point numbers */
-void	__zero__(dp,len)
- Real	*dp;
- int	len;
+void	__zero__(Real *dp, int len)
 {
 #ifdef CHAR0ISDBL0
     /* if a floating point zero is equivalent to a string of nulls */

--- a/src/cpp/meschach/mesch12a/src/machine.c
+++ b/src/cpp/meschach/mesch12a/src/machine.c
@@ -37,15 +37,15 @@ static	char	*rcsid = "$Id: machine.c,v 1.4 1994/01/13 05:28:56 des Exp $";
 
 /* __ip__ -- inner product */
 double	__ip__(dp1,dp2,len)
-register Real	*dp1, *dp2;
+ Real	*dp1, *dp2;
 int	len;
 {
 #ifdef VUNROLL
-    register int	len4;
-    register Real	sum1, sum2, sum3;
+     int	len4;
+     Real	sum1, sum2, sum3;
 #endif
-    register int	i;
-    register Real     sum;
+     int	i;
+     Real     sum;
 
     sum = 0.0;
 #ifdef VUNROLL
@@ -73,13 +73,13 @@ int	len;
 
 /* __mltadd__ -- scalar multiply and add c.f. v_mltadd() */
 void	__mltadd__(dp1,dp2,s,len)
-register Real	*dp1, *dp2;
-register double s;
-register int	len;
+ Real	*dp1, *dp2;
+ double s;
+ int	len;
 {
-    register int	i;
+     int	i;
 #ifdef VUNROLL
-    register int        len4;
+     int        len4;
     
     len4 = len / 4;
     len  = len % 4;
@@ -99,39 +99,39 @@ register int	len;
 
 /* __smlt__ scalar multiply array c.f. sv_mlt() */
 void	__smlt__(dp,s,out,len)
-register Real	*dp, *out;
-register double s;
-register int	len;
+ Real	*dp, *out;
+ double s;
+ int	len;
 {
-    register int	i;
+     int	i;
     for ( i = 0; i < len; i++ )
 	out[i] = s*dp[i];
 }
 
 /* __add__ -- add arrays c.f. v_add() */
 void	__add__(dp1,dp2,out,len)
-register Real	*dp1, *dp2, *out;
-register int	len;
+ Real	*dp1, *dp2, *out;
+ int	len;
 {
-    register int	i;
+     int	i;
     for ( i = 0; i < len; i++ )
 	out[i] = dp1[i] + dp2[i];
 }
 
 /* __sub__ -- subtract arrays c.f. v_sub() */
 void	__sub__(dp1,dp2,out,len)
-register Real	*dp1, *dp2, *out;
-register int	len;
+ Real	*dp1, *dp2, *out;
+ int	len;
 {
-    register int	i;
+     int	i;
     for ( i = 0; i < len; i++ )
 	out[i] = dp1[i] - dp2[i];
 }
 
 /* __zero__ -- zeros an array of floating point numbers */
 void	__zero__(dp,len)
-register Real	*dp;
-register int	len;
+ Real	*dp;
+ int	len;
 {
 #ifdef CHAR0ISDBL0
     /* if a floating point zero is equivalent to a string of nulls */

--- a/src/cpp/meschach/mesch12a/src/matlab.c
+++ b/src/cpp/meschach/mesch12a/src/matlab.c
@@ -40,10 +40,10 @@ static char rcsid[] = "$Id: matlab.c,v 1.8 1995/02/14 20:12:36 des Exp $";
 
 /* m_save -- save matrix in ".mat" file for MATLAB
 	-- returns matrix to be saved */
-MAT     *m_save(fp,A,name)
-FILE    *fp;
-MAT     *A;
-char    *name;
+MAT     *m_save(FILE* fp, MAT* A, char* name)
+//FILE    *fp;
+//MAT     *A;
+//char    *name;
 {
 	int     i;
 	matlab  mat;
@@ -81,10 +81,10 @@ char    *name;
 /* v_save -- save vector in ".mat" file for MATLAB
 	-- saves it as a row vector
 	-- returns vector to be saved */
-VEC     *v_save(fp,x,name)
-FILE    *fp;
-VEC     *x;
-char    *name;
+VEC     *v_save(FILE* fp, VEC* x, char* name)
+//FILE    *fp;
+//VEC     *x;
+//char    *name;
 {
 	matlab  mat;
 
@@ -113,10 +113,10 @@ char    *name;
 /* d_save -- save double in ".mat" file for MATLAB
 	-- saves it as a row vector
 	-- returns vector to be saved */
-double	d_save(fp,x,name)
-FILE    *fp;
-double	x;
-char    *name;
+double	d_save(FILE* fp, double x, char* name)
+//FILE    *fp;
+//double	x;
+//char    *name;
 {
 	matlab  mat;
 	Real x1 = x;
@@ -142,9 +142,9 @@ char    *name;
 
 /* m_load -- loads in a ".mat" file variable as produced by MATLAB
 	-- matrix returned; imaginary parts ignored */
-MAT     *m_load(fp,name)
-FILE    *fp;
-char    **name;
+MAT     *m_load(FILE* fp, char** name)
+//FILE    *fp;
+//char    **name;
 {
 	MAT     *A;
 	int     i;

--- a/src/cpp/meschach/mesch12a/src/matrixio.c
+++ b/src/cpp/meschach/mesch12a/src/matrixio.c
@@ -463,16 +463,16 @@ MAT     *a;
      
      if ( a == (MAT *)NULL )
      {  fprintf(fp,"Matrix: NULL\n");   return;         }
-     fprintf(fp,"Matrix: %d by %d @ 0x%lx\n",a->m,a->n,(long)a);
+     fprintf(fp,"Matrix: %d by %d @ 0x%p\n",a->m,a->n,(size_t)a);
      fprintf(fp,"\tmax_m = %d, max_n = %d, max_size = %d\n",
 	     a->max_m, a->max_n, a->max_size);
      if ( a->me == (Real **)NULL )
      {  fprintf(fp,"NULL\n");           return;         }
-     fprintf(fp,"a->me @ 0x%lx\n",(long)(a->me));
-     fprintf(fp,"a->base @ 0x%lx\n",(long)(a->base));
+     fprintf(fp,"a->me @ 0x%p\n",(size_t)(a->me));
+     fprintf(fp,"a->base @ 0x%p\n",(size_t)(a->base));
      for ( i=0; i<a->m; i++ )   /* for each row... */
      {
-	  fprintf(fp,"row %u: @ 0x%lx ",i,(long)(a->me[i]));
+	  fprintf(fp,"row %u: @ 0x%p ",i,(size_t)(a->me[i]));
 	  for ( j=0, tmp=2; j<a->n; j++, tmp++ )
 	  {             /* for each col in row... */
 	       fprintf(fp,format,a->me[i][j]);
@@ -490,10 +490,10 @@ PERM    *px;
      
      if ( ! px )
      {  fprintf(fp,"Permutation: NULL\n");      return;         }
-     fprintf(fp,"Permutation: size: %u @ 0x%lx\n",px->size,(long)(px));
+     fprintf(fp,"Permutation: size: %u @ 0x%p\n",px->size,(size_t)(px));
      if ( ! px->pe )
      {  fprintf(fp,"NULL\n");   return;         }
-     fprintf(fp,"px->pe @ 0x%lx\n",(long)(px->pe));
+     fprintf(fp,"px->pe @ 0x%p\n",(size_t)(px->pe));
      for ( i=0; i<px->size; i++ )
 	  fprintf(fp,"%u->%u ",i,px->pe[i]);
      fprintf(fp,"\n");
@@ -508,10 +508,10 @@ VEC     *x;
      
      if ( ! x )
      {  fprintf(fp,"Vector: NULL\n");   return;         }
-     fprintf(fp,"Vector: dim: %d @ 0x%lx\n",x->dim,(long)(x));
+     fprintf(fp,"Vector: dim: %d @ 0x%p\n",x->dim,(size_t)(x));
      if ( ! x->ve )
      {  fprintf(fp,"NULL\n");   return;         }
-     fprintf(fp,"x->ve @ 0x%lx\n",(long)(x->ve));
+     fprintf(fp,"x->ve @ 0x%p\n",(size_t)(x->ve));
      for ( i=0, tmp=0; i<x->dim; i++, tmp++ )
      {
 	  fprintf(fp,format,x->ve[i]);

--- a/src/cpp/meschach/mesch12a/src/matrixio.c
+++ b/src/cpp/meschach/mesch12a/src/matrixio.c
@@ -463,16 +463,16 @@ MAT     *a;
      
      if ( a == (MAT *)NULL )
      {  fprintf(fp,"Matrix: NULL\n");   return;         }
-     fprintf(fp,"Matrix: %d by %d @ 0x%p\n",a->m,a->n,(size_t)a);
+     fprintf(fp,"Matrix: %d by %d @ 0x%p\n",a->m,a->n,(void *)a);
      fprintf(fp,"\tmax_m = %d, max_n = %d, max_size = %d\n",
 	     a->max_m, a->max_n, a->max_size);
      if ( a->me == (Real **)NULL )
      {  fprintf(fp,"NULL\n");           return;         }
-     fprintf(fp,"a->me @ 0x%p\n",(size_t)(a->me));
-     fprintf(fp,"a->base @ 0x%p\n",(size_t)(a->base));
+     fprintf(fp,"a->me @ 0x%p\n",(void *)(a->me));
+     fprintf(fp,"a->base @ 0x%p\n",(void *)(a->base));
      for ( i=0; i<a->m; i++ )   /* for each row... */
      {
-	  fprintf(fp,"row %u: @ 0x%p ",i,(size_t)(a->me[i]));
+	  fprintf(fp,"row %u: @ 0x%p ",i,(void *)(a->me[i]));
 	  for ( j=0, tmp=2; j<a->n; j++, tmp++ )
 	  {             /* for each col in row... */
 	       fprintf(fp,format,a->me[i][j]);
@@ -490,10 +490,10 @@ PERM    *px;
      
      if ( ! px )
      {  fprintf(fp,"Permutation: NULL\n");      return;         }
-     fprintf(fp,"Permutation: size: %u @ 0x%p\n",px->size,(size_t)(px));
+     fprintf(fp,"Permutation: size: %u @ 0x%p\n",px->size,(void *)(px));
      if ( ! px->pe )
      {  fprintf(fp,"NULL\n");   return;         }
-     fprintf(fp,"px->pe @ 0x%p\n",(size_t)(px->pe));
+     fprintf(fp,"px->pe @ 0x%p\n",(void *)(px->pe));
      for ( i=0; i<px->size; i++ )
 	  fprintf(fp,"%u->%u ",i,px->pe[i]);
      fprintf(fp,"\n");
@@ -508,10 +508,10 @@ VEC     *x;
      
      if ( ! x )
      {  fprintf(fp,"Vector: NULL\n");   return;         }
-     fprintf(fp,"Vector: dim: %d @ 0x%p\n",x->dim,(size_t)(x));
+     fprintf(fp,"Vector: dim: %d @ 0x%p\n",x->dim,(void *)(x));
      if ( ! x->ve )
      {  fprintf(fp,"NULL\n");   return;         }
-     fprintf(fp,"x->ve @ 0x%p\n",(size_t)(x->ve));
+     fprintf(fp,"x->ve @ 0x%p\n",(void *)(x->ve));
      for ( i=0, tmp=0; i<x->dim; i++, tmp++ )
      {
 	  fprintf(fp,format,x->ve[i]);

--- a/src/cpp/meschach/mesch12a/src/memstat.c
+++ b/src/cpp/meschach/mesch12a/src/memstat.c
@@ -30,6 +30,7 @@
 
 
 #include <stdio.h>
+#include <stdint.h>
 #include  "matrix.h"
 #include  "meminfo.h"
 #ifdef COMPLEXE   
@@ -77,10 +78,9 @@ static unsigned int mem_hash_idx_end = 0;
 
 /* hashing function */
 
-static unsigned int mem_hash(ptr)
-void **ptr;
+static unsigned int mem_hash(void **ptr)
 {
-   unsigned long lp = (unsigned long)ptr;
+   uintptr_t lp = (uintptr_t)ptr;
 
    return (lp % MEM_HASHSIZE);
 }

--- a/src/cpp/meschach/mesch12a/src/otherio.c
+++ b/src/cpp/meschach/mesch12a/src/otherio.c
@@ -45,9 +45,9 @@ static	int	y_n_dflt = TRUE;
 /* fy_or_n -- yes-or-no to question is string s
 	-- question written to stderr, input from fp 
 	-- if fp is NOT a tty then return y_n_dflt */
-int	fy_or_n(fp,s)
-FILE	*fp;
-char	*s;
+int	fy_or_n(FILE* fp, char* s)
+//FILE	*fp;
+//char	*s;
 {
 	char	*cp;
 
@@ -72,8 +72,8 @@ char	*s;
 }
 
 /* yn_dflt -- sets the value of y_n_dflt to val */
-int	yn_dflt(val)
-int	val;
+int	yn_dflt(int val)
+//int	val;
 {	return y_n_dflt = val;		}
 
 /* fin_int -- return integer read from file/stream fp
@@ -81,10 +81,10 @@ int	val;
 	-- check that x lies between low and high: re-prompt if
 		fp is a tty, error exit otherwise
 	-- ignore check if low > high		*/
-int	fin_int(fp,s,low,high)
-FILE	*fp;
-char	*s;
-int	low, high;
+int	fin_int(FILE* fp, char* s, int low, int high)
+//FILE	*fp;
+//char	*s;
+//int	low, high;
 {
 	int	retcode, x;
 
@@ -120,10 +120,10 @@ int	low, high;
 	-- check that x lies between low and high: re-prompt if
 		fp is a tty, error exit otherwise
 	-- ignore check if low > high		*/
-double	fin_double(fp,s,low,high)
-FILE	*fp;
-char	*s;
-double	low, high;
+double	fin_double(FILE* fp, char* s, double low, double high)
+//FILE	*fp;
+//char	*s;
+//double	low, high;
 {
 	Real	retcode, x;
 

--- a/src/cpp/meschach/mesch12a/src/sparseio.c
+++ b/src/cpp/meschach/mesch12a/src/sparseio.c
@@ -134,11 +134,11 @@ SPMAT  *A;
 	fprintf(fp,"SparseMatrix dump:\n");
 	if ( ! A )
 	{       fprintf(fp,"*** NULL ***\n");   return; }
-	fprintf(fp,"Matrix at 0x%lx\n",(long)A);
+	fprintf(fp,"Matrix at 0x%p\n",(void *)A);
 	fprintf(fp,"Dimensions: %d by %d\n",A->m,A->n);
 	fprintf(fp,"MaxDimensions: %d by %d\n",A->max_m,A->max_n);
 	fprintf(fp,"flag_col = %d, flag_diag = %d\n",A->flag_col,A->flag_diag);
-	fprintf(fp,"start_row @ 0x%lx:\n",(long)(A->start_row));
+	fprintf(fp,"start_row @ 0x%p:\n",(void *)(A->start_row));
 	for ( j = 0; j < A->n; j++ )
 	{
 		fprintf(fp,"%d ",A->start_row[j]);
@@ -146,7 +146,7 @@ SPMAT  *A;
 			fprintf(fp,"\n");
 	}
 	fprintf(fp,"\n");
-	fprintf(fp,"start_idx @ 0x%lx:\n",(long)(A->start_idx));
+	fprintf(fp,"start_idx @ 0x%p:\n",(void *)(A->start_idx));
 	for ( j = 0; j < A->n; j++ )
 	{
 		fprintf(fp,"%d ",A->start_idx[j]);
@@ -154,7 +154,7 @@ SPMAT  *A;
 			fprintf(fp,"\n");
 	}
 	fprintf(fp,"\n");
-	fprintf(fp,"Rows @ 0x%lx:\n",(long)(A->row));
+	fprintf(fp,"Rows @ 0x%p:\n",(void *)(A->row));
 	if ( ! A->row )
 	{       fprintf(fp,"*** NULL row ***\n");       return; }
 	rows = A->row;
@@ -162,7 +162,7 @@ SPMAT  *A;
 	{
 		fprintf(fp,"row %d: len = %d, maxlen = %d, diag idx = %d\n",
 			i,rows[i].len,rows[i].maxlen,rows[i].diag);
-		fprintf(fp,"element list @ 0x%lx\n",(long)(rows[i].elt));
+		fprintf(fp,"element list @ 0x%p\n",(void *)(rows[i].elt));
 		if ( ! rows[i].elt )
 		{
 			fprintf(fp,"*** NULL element list ***\n");

--- a/src/cpp/meschach/mesch12a/src/sparseio.c
+++ b/src/cpp/meschach/mesch12a/src/sparseio.c
@@ -259,7 +259,9 @@ FILE    *fp;
 	{
 	        ret_val = 0;
 		skipjunk(fp);
-		fscanf(fp,"SparseMatrix:");
+		if (fscanf(fp, "SparseMatrix:") != 0) {
+    		error(E_INPUT, "sp_finput");
+		}
 		skipjunk(fp);
 		if ( (ret_val=fscanf(fp,"%u by %u",&m,&n)) != 2 )
 		    error((ret_val == EOF) ? E_EOF : E_FORMAT,"sp_finput");

--- a/src/cpp/meschach/mesch12a/src/spchfctr.c
+++ b/src/cpp/meschach/mesch12a/src/spchfctr.c
@@ -54,8 +54,8 @@ int	lim;
 {
 	int			idx1, idx2, len1, len2, tmp;
 	int			sprow_idx();
-	register row_elt	*elts1, *elts2;
-	register Real		sum;
+	row_elt	*elts1, *elts2;
+	Real		sum;
 
 	elts1 = row1->elt;	elts2 = row2->elt;
 	len1 = row1->len;	len2 = row2->len;
@@ -179,7 +179,7 @@ int	new_len;
 SPMAT	*spCHfactor(A)
 SPMAT	*A;
 {
-	register 	int	i;
+		int	i;
 	int	idx, k, m, minim, n, num_scan, diag_idx, tmp1;
 	Real	pivot, tmp2;
 	SPROW	*r_piv, *r_op;
@@ -444,7 +444,7 @@ SPMAT	*A;
 SPMAT	*spCHsymb(A)
 SPMAT	*A;
 {
-	register 	int	i;
+		int	i;
 	int	idx, k, m, minim, n, num_scan, diag_idx, tmp1;
 	SPROW	*r_piv, *r_op;
 	row_elt	*elt_piv, *elt_op, *old_elt;

--- a/src/cpp/meschach/mesch12a/src/sprow.c
+++ b/src/cpp/meschach/mesch12a/src/sprow.c
@@ -75,9 +75,9 @@ int	sprow_idx(r,col)
 SPROW	*r;
 int	col;
 {
-   register int		lo, hi, mid;
+   int		lo, hi, mid;
    int			tmp;
-   register row_elt	*r_elt;
+   row_elt	*r_elt;
    
    /*******************************************
      if ( r == (SPROW *)NULL )

--- a/src/cpp/meschach/mesch12a/src/sprow.c
+++ b/src/cpp/meschach/mesch12a/src/sprow.c
@@ -54,7 +54,7 @@ SPROW *r;
    
    fprintf(fp,"row: len = %d, maxlen = %d, diag idx = %d\n",
 	   r->len,r->maxlen,r->diag);
-   fprintf(fp,"element list @ 0x%lx\n",(long)(r->elt));
+   fprintf(fp,"element list @ 0x%p\n",(void *)(r->elt));
    if ( ! r->elt )
    {
       fprintf(fp,"*** NULL element list ***\n");

--- a/src/cpp/meschach/mesch12a_v0/src/err.c
+++ b/src/cpp/meschach/mesch12a_v0/src/err.c
@@ -214,7 +214,7 @@ extern  int	count_errs(int flag)
    list_num is an error list number (0 is the basic list 
    pointed by err_mesg, 1 is the basic list of warnings)
  */
-extern  int	ev_err(char *file, int err_num, int line_num, char *fn_name, int list_num)
+extern  int	ev_err(char *file, int err_num, int line_num, const char *fn_name, int list_num)
 {
    int	num;
    

--- a/src/cpp/meschach/mesch12a_v0/src/machine.c
+++ b/src/cpp/meschach/mesch12a_v0/src/machine.c
@@ -35,11 +35,11 @@ static	char *rcsid = "$Header: /usr/local/home/des/meschach/meschach/RCS/machine
 #include	"machine.h"
 
 /* __ip__ -- inner product */
-extern  double	__ip__(register double *dp1,register double *dp2, register int len)
+extern  double	__ip__(double *dp1,double *dp2, int len)
 {
-    register int	len4;
-    register int	i;
-    register double	sum0, sum1, sum2, sum3;
+    int	len4;
+    int	i;
+    double	sum0, sum1, sum2, sum3;
     
     sum0 = sum1 = sum2 = sum3 = 0.0;
     
@@ -63,9 +63,9 @@ extern  double	__ip__(register double *dp1,register double *dp2, register int le
 }
 
 /* __mltadd__ -- scalar multiply and add c.f. v_mltadd() */
-extern  void	__mltadd__(register double *dp1, register double *dp2, register double s, register int len)
+extern  void	__mltadd__(double *dp1, double *dp2, double s, int len)
 {
-    register int	i, len4;
+    int	i, len4;
     
     len4 = len / 4;
     len  = len % 4;
@@ -83,31 +83,31 @@ extern  void	__mltadd__(register double *dp1, register double *dp2, register dou
 }
 
 /* __smlt__ scalar multiply array c.f. sv_mlt() */
-extern  void	__smlt__(register double *dp,register double s, register double	*out, register int len)
+extern  void	__smlt__(double *dp,double s, double	*out, int len)
 {
-    register int	i;
+    int	i;
     for ( i = 0; i < len; i++ )
 	(*out++) = s*(*dp++);
 }
 
 /* __add__ -- add arrays c.f. v_add() */
-extern  void	__add__(register double	*dp1, register double *dp2,register double *out,register int len)
+extern  void	__add__(double	*dp1, double *dp2,double *out,int len)
 {
-    register int	i;
+    int	i;
     for ( i = 0; i < len; i++ )
 	(*out++) = (*dp1++) + (*dp2++);
 }
 
 /* __sub__ -- subtract arrays c.f. v_sub() */
-extern  void	__sub__(register double	*dp1, register double *dp2, register double *out, register int len)
+extern  void	__sub__(double	*dp1, double *dp2, double *out, int len)
 {
-    register int	i;
+    int	i;
     for ( i = 0; i < len; i++ )
 	(*out++) = (*dp1++) - (*dp2++);
 }
 
 /* __zero__ -- zeros an array of double precision numbers */
-extern  void	__zero__(register double *dp,register int len)
+extern  void	__zero__(double *dp,int len)
 {
     /* if a double precision zero is equivalent to a string of nulls */
     MEM_ZERO((char *)dp,len*sizeof(double));
@@ -125,9 +125,9 @@ extern  void	__zero__(register double *dp,register int len)
 /* __ip4__ -- compute 4 inner products in one go */
 extern  void	__ip4__(double *v0,double *v1,double *v2,double *v3,double *w,double out[4], int len)
 {
-    register int	i, len2;
-    register double	sum00, sum10, sum20, sum30, w_val0;
-    register double	sum01, sum11, sum21, sum31, w_val1;
+    int	i, len2;
+    double	sum00, sum10, sum20, sum30, w_val0;
+    double	sum01, sum11, sum21, sum31, w_val1;
     
     len2 = len / 2;
     len  = len % 2;
@@ -168,8 +168,8 @@ extern  void	__ip4__(double *v0,double *v1,double *v2,double *v3,double *w,doubl
 /* __lc4__ -- linear combinations: w <- w+a[0]*v0+ ... + a[3]*v3 */
 extern  void	__lc4__(double *v0,double *v1,double *v2,double *v3,double *w,double	a[4], int len)
 {
-    register int	i, len2;
-    register double	a0, a1, a2, a3, tmp0, tmp1;
+    int	i, len2;
+    double	a0, a1, a2, a3, tmp0, tmp1;
     
     len2 = len / 2;
     len  = len % 2;
@@ -201,8 +201,8 @@ extern  void	__lc4__(double *v0,double *v1,double *v2,double *v3,double *w,doubl
 /* __ma4__ -- multiply and add with 4 vectors: vi <- vi + ai*w */
 extern  void	__ma4__(double *v0,double *v1,double *v2,double *v3,double *w,double	a[4], int len)
 {
-    register int	i;
-    register double	a0, a1, a2, a3, w0;
+    int	i;
+    double	a0, a1, a2, a3, w0;
 
     a0 = a[0];	a1 = a[1];
     a2 = a[2];	a3 = a[3];

--- a/src/cpp/meschach/mesch12a_v0/src/spchfctr.c
+++ b/src/cpp/meschach/mesch12a_v0/src/spchfctr.c
@@ -54,8 +54,8 @@ SPMAT	*comp_AAT(SPMAT *A);
 double	sprow_ip(SPROW *row1, SPROW *row2, int lim)
 {
 	int			idx1, idx2, len1, len2, tmp;
-	register row_elt	*elts1, *elts2;
-	register Real		sum;
+	row_elt	*elts1, *elts2;
+	Real		sum;
 
 	elts1 = row1->elt;	elts2 = row2->elt;
 	len1 = row1->len;	len2 = row2->len;
@@ -175,7 +175,7 @@ int	set_scan(int new_len)
 	-- only the lower triangular part of A (incl. diagonal) is used */
 extern  SPMAT	*spCHfactor(SPMAT *A)
 {
-	register 	int	i;
+		int	i;
 	int	idx, k, m, minim, n, num_scan, diag_idx, tmp1;
 	Real	pivot, tmp2;
 	SPROW	*r_piv, *r_op;
@@ -436,7 +436,7 @@ extern  SPMAT	*spICHfactor(SPMAT *A)
 	-- only the lower triangular part of A (incl. diagonal) is used */
 extern  SPMAT	*spCHsymb(SPMAT *A)
 {
-	register 	int	i;
+		int	i;
 	int	idx, k, m, minim, n, num_scan, diag_idx, tmp1;
 	SPROW	*r_piv, *r_op;
 	row_elt	*elt_piv, *elt_op, *old_elt;

--- a/src/cpp/meschach/mesch12a_v0/src/sprow.c
+++ b/src/cpp/meschach/mesch12a_v0/src/sprow.c
@@ -67,9 +67,9 @@ extern  void sprow_dump(FILE *fp, SPROW *r)
    -- return -(idx+2) where idx is index to insertion point */
 extern  int	sprow_idx(SPROW	*r, int col)
 {
-   register int		lo, hi, mid;
+   int		lo, hi, mid;
    int			tmp;
-   register row_elt	*r_elt;
+   row_elt	*r_elt;
    
    /*******************************************
      if ( r == (SPROW *)NULL )

--- a/src/cpp/s2v/src/envoi.c
+++ b/src/cpp/s2v/src/envoi.c
@@ -8,7 +8,7 @@ main(int argc, char **argv){
   int n,t;
   double id;
   FILE * fout;
-  register int i,j,k;
+  int i,j,k;
   char cmd[50];
   int shmid;
   bool prog=false;

--- a/src/cpp/s2v/src/s2v.cpp
+++ b/src/cpp/s2v/src/s2v.cpp
@@ -801,7 +801,7 @@ double  lectri(signed char &test,char &ntype,int &natt,long i_att[],int &nsom,Pa
     fscanf(fichier, "%c", &fin);
   } while(fin!='p' && !feof(fichier));
   if(!feof(fichier)) {
-    fseek(fichier,-sizeof(char),SEEK_CUR);
+    fseek(fichier,-(long)sizeof(char),SEEK_CUR);
     //fputc(fin, fichier);
   } // if
 

--- a/src/cpp/s2v/src/s2v.cpp
+++ b/src/cpp/s2v/src/s2v.cpp
@@ -515,7 +515,7 @@ int s2v(int argc, char **argv){
 
   if(segpar){
 #ifndef WIN32
-    shmdt((void*)shmid); //ShMDetach
+    shmdt((void*)(size_t)shmid); //ShMDetach
 #else
     UnmapViewOfFile(lpSharedSeg) ; // invalidation du ptr sur mem partagee
     // Ts = NULL ;		   // Tester avant


### PR DESCRIPTION
Lots of warnings :

1. **function prototype** 
warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
2. **'sprintf' is deprecated**
This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
3. **casting void* to int**
warning: cast to 'void *' from smaller integer type 'int' 
## Solutions 
1. Prototypes
```C
MAT	*_m_copy(in,out,i0,j0)
MAT	*in,*out;
u_int	i0,j0;
```
```C
MAT	*_m_copy(MAT* in, MAT* out, u_int i0, u_intj0)
//MAT	*in,*out; 
```
2. sprintf
```C
sprintf(optname,"%s.opt",argv[MIN_OPT]);
```
replaced by
```C
snprintf(optname,sizeof(optname), "%s.opt",argv[MIN_OPT]);
```
3. casting
```C
    shmdt((void*)shmid); //ShMDetach
```
to
```C
    shmdt((void*)(size_t)shmid); //ShMDetach
```